### PR TITLE
Properly handle short integer overflow in PushShortIns.execute

### DIFF
--- a/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/abc/avm2/instructions/stack/PushShortIns.java
+++ b/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/abc/avm2/instructions/stack/PushShortIns.java
@@ -38,7 +38,7 @@ public class PushShortIns extends InstructionDefinition implements PushIntegerTy
 
     @Override
     public void execute(LocalDataArea lda, AVM2ConstantPool constants, List<Object> arguments) {
-        lda.operandStack.push(arguments.get(0));
+        lda.operandStack.push((long) ((Number) arguments.get(0)).shortValue());
     }
 
     @Override


### PR DESCRIPTION
`translate` method already handles instructions like `pushshort 107373249` properly, I believe `execute` should as well.
