### PR TITLE
Empty execute method for nop, debug, debugfile and debugline

### DIFF
--- a/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/abc/avm2/instructions/debug/DebugFileIns.java
+++ b/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/abc/avm2/instructions/debug/DebugFileIns.java
@@ -16,11 +16,18 @@
 package com.jpexs.decompiler.flash.abc.avm2.instructions.debug;
 
 import com.jpexs.decompiler.flash.abc.avm2.AVM2Code;
+import com.jpexs.decompiler.flash.abc.avm2.AVM2ConstantPool;
+import com.jpexs.decompiler.flash.abc.avm2.LocalDataArea;
 import com.jpexs.decompiler.flash.abc.avm2.instructions.InstructionDefinition;
+import java.util.List;
 
 public class DebugFileIns extends InstructionDefinition {
 
     public DebugFileIns() {
         super(0xf1, "debugfile", new int[]{AVM2Code.DAT_STRING_INDEX});
+    }
+
+    @Override
+    public void execute(LocalDataArea lda, AVM2ConstantPool constants, List<Object> arguments) {
     }
 }

--- a/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/abc/avm2/instructions/debug/DebugIns.java
+++ b/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/abc/avm2/instructions/debug/DebugIns.java
@@ -16,11 +16,18 @@
 package com.jpexs.decompiler.flash.abc.avm2.instructions.debug;
 
 import com.jpexs.decompiler.flash.abc.avm2.AVM2Code;
+import com.jpexs.decompiler.flash.abc.avm2.AVM2ConstantPool;
+import com.jpexs.decompiler.flash.abc.avm2.LocalDataArea;
 import com.jpexs.decompiler.flash.abc.avm2.instructions.InstructionDefinition;
+import java.util.List;
 
 public class DebugIns extends InstructionDefinition {
 
     public DebugIns() {
         super(0xef, "debug", new int[]{AVM2Code.DAT_DEBUG_TYPE, AVM2Code.DAT_STRING_INDEX, AVM2Code.DAT_REGISTER_INDEX, AVM2Code.OPT_U30});
+    }
+
+    @Override
+    public void execute(LocalDataArea lda, AVM2ConstantPool constants, List<Object> arguments) {
     }
 }

--- a/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/abc/avm2/instructions/debug/DebugLineIns.java
+++ b/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/abc/avm2/instructions/debug/DebugLineIns.java
@@ -16,11 +16,18 @@
 package com.jpexs.decompiler.flash.abc.avm2.instructions.debug;
 
 import com.jpexs.decompiler.flash.abc.avm2.AVM2Code;
+import com.jpexs.decompiler.flash.abc.avm2.AVM2ConstantPool;
+import com.jpexs.decompiler.flash.abc.avm2.LocalDataArea;
 import com.jpexs.decompiler.flash.abc.avm2.instructions.InstructionDefinition;
+import java.util.List;
 
 public class DebugLineIns extends InstructionDefinition {
 
     public DebugLineIns() {
         super(0xf0, "debugline", new int[]{AVM2Code.DAT_LINENUM});
+    }
+
+    @Override
+    public void execute(LocalDataArea lda, AVM2ConstantPool constants, List<Object> arguments) {
     }
 }

--- a/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/abc/avm2/instructions/other/NopIns.java
+++ b/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/abc/avm2/instructions/other/NopIns.java
@@ -15,11 +15,18 @@
  * License along with this library. */
 package com.jpexs.decompiler.flash.abc.avm2.instructions.other;
 
+import com.jpexs.decompiler.flash.abc.avm2.AVM2ConstantPool;
+import com.jpexs.decompiler.flash.abc.avm2.LocalDataArea;
 import com.jpexs.decompiler.flash.abc.avm2.instructions.InstructionDefinition;
+import java.util.List;
 
 public class NopIns extends InstructionDefinition {
 
     public NopIns() {
         super(0x02, "nop", new int[]{});
+    }
+
+    @Override
+    public void execute(LocalDataArea lda, AVM2ConstantPool constants, List<Object> arguments) {
     }
 }


### PR DESCRIPTION
I think having those instructions throw `UnsupportedOperationException` when you try to execute them is not very convenient.
