### PR TITLE
Changes to get jpexs building on Linux.

### DIFF
--- a/libsrc/ffdec_lib/build_common.xml
+++ b/libsrc/ffdec_lib/build_common.xml
@@ -239,11 +239,10 @@
                 <globmapper from="*" to="/*"/>
             </chainedmapper>
         </pathconvert>
-        
         <script language="javascript"><![CDATA[
         var classpath = project.getProperty("lexers");
-        var parts = classpath.split("|");
-        for each (var part in parts) {        
+        var parts = classpath.split('\\|');
+        for each (var part in parts) {
             project.setProperty("lexer",project.getProperty("LEXERSDIR")+part);
             self.project.executeTarget("-lexer");
         }

--- a/libsrc/ffdec_lib/test/com/jpexs/decompiler/flash/RecompileTest.java
+++ b/libsrc/ffdec_lib/test/com/jpexs/decompiler/flash/RecompileTest.java
@@ -161,8 +161,8 @@ public class RecompileTest {
             });
         }
         Object[][] ret = new Object[files.length + 2][1];
-        ret[0][0] = "..\\as2\\as2.swf";
-        ret[1][0] = "..\\as3\\as3.swf";
+        ret[0][0] = "../as2/as2.swf";
+        ret[1][0] = "../as3/as3.swf";
         for (int f = 0; f < files.length; f++) {
             ret[f + 2][0] = files[f].getName();
         }


### PR DESCRIPTION
The classpath.split() argument was being interpreted as a regex on my system, so it was splitting between every character, rather than just at the `|`s, and thus the build was failing. This seems to be the case because classpath is a _Java_ string rather than a _JavaScript_ string, and thus with [different semantics](http://stackoverflow.com/questions/20244995/strange-result-of-javascript-split-in-ant) of it's `.split()` method.

Also change to using forward slashes rather than backslashes for the tests, these should work on both Linux and Windows.
