### PR TITLE
Fix startup script ffdec.sh for OpenJDK 8

### DIFF
--- a/resources/ffdec.sh
+++ b/resources/ffdec.sh
@@ -52,7 +52,7 @@ cd "`dirname \"$PROGRAM\"`"
 # Check default java
 if [ -x "`which java`" ]; then
 	JAVA_VERSION_OUTPUT=`java -version 2>&1`
-    JAVA_VERSION_OUTPUT=`echo $JAVA_VERSION_OUTPUT | sed 's/openjdk version/java version/'`
+	JAVA_VERSION_OUTPUT=`echo $JAVA_VERSION_OUTPUT | sed 's/openjdk version/java version/'`
 	check_java_version && exec java -Djava.net.preferIPv4Stack=true -Xmx$MEMORY -jar $JAR_FILE "$@"
 fi
 
@@ -60,7 +60,7 @@ fi
 for JRE_PATH in $LOOKUP_JRE_DIRS; do
 	if [ -x "$JRE_PATH/bin/java" ]; then
 		JAVA_VERSION_OUTPUT=`"$JRE_PATH/bin/java" -version 2>&1`
-        JAVA_VERSION_OUTPUT=`echo $JAVA_VERSION_OUTPUT | sed 's/openjdk version/java version/'`
+		JAVA_VERSION_OUTPUT=`echo $JAVA_VERSION_OUTPUT | sed 's/openjdk version/java version/'`
 		check_java_version && {
 			export JRE_PATH
 			exec $JRE_PATH/bin/java -Djava.net.preferIPv4Stack=true -Xmx$MEMORY -jar $JAR_FILE "$@"

--- a/resources/ffdec.sh
+++ b/resources/ffdec.sh
@@ -52,6 +52,7 @@ cd "`dirname \"$PROGRAM\"`"
 # Check default java
 if [ -x "`which java`" ]; then
 	JAVA_VERSION_OUTPUT=`java -version 2>&1`
+    JAVA_VERSION_OUTPUT=`echo $JAVA_VERSION_OUTPUT | sed 's/openjdk version/java version/'`
 	check_java_version && exec java -Djava.net.preferIPv4Stack=true -Xmx$MEMORY -jar $JAR_FILE "$@"
 fi
 
@@ -59,6 +60,7 @@ fi
 for JRE_PATH in $LOOKUP_JRE_DIRS; do
 	if [ -x "$JRE_PATH/bin/java" ]; then
 		JAVA_VERSION_OUTPUT=`"$JRE_PATH/bin/java" -version 2>&1`
+        JAVA_VERSION_OUTPUT=`echo $JAVA_VERSION_OUTPUT | sed 's/openjdk version/java version/'`
 		check_java_version && {
 			export JRE_PATH
 			exec $JRE_PATH/bin/java -Djava.net.preferIPv4Stack=true -Xmx$MEMORY -jar $JAR_FILE "$@"


### PR DESCRIPTION
OpenJDK 8 uses some different strings for version representation. An extra `sed` is necessary for correct executation.

Additionally, current commit does not build on neither Sun JDK 7 nor OpenJDK 7 due the use of String.join() in several source files. Please update related descriptions.