### PR TITLE
Add support for non-standard ABC-compressed SWF file

### DIFF
--- a/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/ABCFormat.txt
+++ b/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/ABCFormat.txt
@@ -1,0 +1,22 @@
+ABC format is a non-standard LZMA format. It's seen in letv.com. The file layout is depicted as below:
+
+| 4 bytes       | 4 bytes   | The remaining part
+| 'ABC'+version | scriptLen | Standard LZMA data
+
+And standard LZMA data is encoded as:
+
+| 5 bytes           | 8 bytes               | The remaining part
+| LZMA properties   | uncompressed length   | LZMA-compressed data
+
+For more information, visit the following pages:
+
+1. Difference between standard LZMA format and ZWC (LZMA-compressed SWF) format
+   https://helpx.adobe.com/flash-player/kb/exception-thrown-you-decompress-lzma-compressed.html
+2. How to decrypt KLetvPlayer.swf from letv.com
+   http://blog.csdn.net/lingedeng/article/details/37599347
+3. The source codes for encoding and decoding ABC format
+   com/alex/encrypt/ABCSwfEncrypt.as in LetvPlayer.swf
+
+LetvPlayer.swf and KLetvPlayer.swf mentioned above can be found at:
+http://player.letvcdn.com/p/201502/05/17/newplayer/LetvPlayer.swf
+http://player.letvcdn.com/p/201502/05/17/newplayer/1/KLetvPlayer.swf


### PR DESCRIPTION
The SWF file KLetvPlayer.swf I mentioned in ABCFormat.txt is compressed with a non-standard method. I hope this patch helps opening such files without an additional conversion step.

Sorry for that I'm not familiar with the class SWFInputStream so that I use InputStream directly. Also, there's no error checking for the format ABC.