### PR TITLE
Fix decompilation errors: Improved TranslateStack handling

### DIFF
--- a/libsrc/ffdec_lib/src/com/jpexs/decompiler/graph/GraphPart.java
+++ b/libsrc/ffdec_lib/src/com/jpexs/decompiler/graph/GraphPart.java
@@ -57,6 +57,35 @@ public class GraphPart implements Serializable {
 
     public List<GraphPart> throwParts = new ArrayList<>();
 
+    public enum StopPartType {
+        NONE, AND_OR, COMMONPART
+    }
+
+    public StopPartType stopPartType = StopPartType.NONE;
+
+    public TranslateStack andOrStack; // Stores stack when AND_OR stopPart has been reached
+
+    public class CommonPartStack { // Stores stack when COMMONPART stopPart has been reached
+      boolean isTrueStack;
+      TranslateStack trueStack;
+      TranslateStack falseStack;
+    }
+
+    public ArrayList<CommonPartStack> commonPartStacks;
+    
+    public void setAndOrStack(TranslateStack stack) {
+      andOrStack = stack;
+    }
+
+    public void setCommonPartStack(TranslateStack stack) {
+       CommonPartStack currentStack = commonPartStacks.get(commonPartStacks.size()-1);
+       if (currentStack.isTrueStack) {
+           currentStack.trueStack = stack;
+       } else {
+           currentStack.falseStack = stack;
+       }
+    }
+
     public int setTime(int time, List<GraphPart> ordered, List<GraphPart> visited) {
         if (visited.contains(this)) {
             return time;


### PR DESCRIPTION
...to cope better with stack cloning.

This commit fixes the handling of the TranslateStack after the stack has been cloned in one of the later printGraph calls.

For example, in the AND/OR detection there is the following in the original code:
> printGraph(...,stack,...,stopPart2,...)
> GraphTargetItem second = stack.pop();
> GraphTargetItem first = stack.pop();

After the printGraph call, it is assumed that stack equals the stack at the moment that the stopPart has been reached.
Although this is true in many cases because printGraph just processes the stack, it is not true in the case where the stack has been cloned somewhere in the printGraph call, resulting in failure of the stack.pop() by EmptyStackexception.
This typically happens when a lot of AND/OR and if-then-else are nested.

A similar problem exists for the if-then-else and ternary operator detection: Cloning deeper in the printGraph calls can mess up the stacks resulting in exceptions. This stack mismatch can also unwantedly trigger the code after
"if (trueStack.size() != trueStackSizeBefore || falseStack.size() != falseStackSizeBefore)", because the trueStack.size() and falseStack.size() can report incorrect values.

This commit fixes this by storing the stack at the moment the stopPart has been reached.
For the if-then-else and ternary, both the truestack and falsestack need to be stored upon reaching the stopPart.
Then when the printGraph returns, the stored stacks are fetched for further use by the existing code.

I re-used the GraphPart class for storing the stack/stopPart information as it seemed to have least impact.

I will create an issue in the issue tracker with a reference to a file that has several decompilation errors fixed by this commit
