### PR TITLE
Fix decompilation error: ClassCastException in AND/OR detection.

### DIFF
--- a/libsrc/ffdec_lib/src/com/jpexs/decompiler/graph/Graph.java
+++ b/libsrc/ffdec_lib/src/com/jpexs/decompiler/graph/Graph.java
@@ -1471,7 +1471,7 @@ public class Graph {
                             a.firstPart = ((AndItem) second).firstPart;
                         }
                         if (second instanceof OrItem) {
-                            a.firstPart = ((AndItem) second).firstPart;
+                            a.firstPart = ((OrItem) second).firstPart;
                         }
                     } else {
                         OrItem o = new OrItem(null, first, second);
@@ -1480,8 +1480,8 @@ public class Graph {
                         if (second instanceof OrItem) {
                             o.firstPart = ((OrItem) second).firstPart;
                         }
-                        if (second instanceof OrItem) {
-                            o.firstPart = ((OrItem) second).firstPart;
+                        if (second instanceof AndItem) {
+                            o.firstPart = ((AndItem) second).firstPart;
                         }
                     }
 


### PR DESCRIPTION
Hi again,

This small commit fixes a ClassCastException I had in the AND/OR detection. 
The fix should not break any other decompilations since hitting this part of the code always results in the exception.
What is the intention exactly of the GraphTargetItem.firstPart member ? I did not see any specific use of it in the code.
Greetings,
Jackkal. 