### PR TITLE
Fix ActionEnumerate2 - Null should be considered part of EnumerateAction...

### DIFF
--- a/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/action/swf6/ActionEnumerate2.java
+++ b/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/action/swf6/ActionEnumerate2.java
@@ -12,7 +12,8 @@
  * Lesser General Public License for more details.
  * 
  * You should have received a copy of the GNU Lesser General Public
- * License along with this library. */
+ * License along with this library.
+ */
 package com.jpexs.decompiler.flash.action.swf6;
 
 import com.jpexs.decompiler.flash.action.Action;
@@ -39,7 +40,6 @@ public class ActionEnumerate2 extends Action {
     @Override
     public void translate(TranslateStack stack, List<GraphTargetItem> output, HashMap<Integer, String> regNames, HashMap<String, GraphTargetItem> variables, HashMap<String, GraphTargetItem> functions, int staticOperation, String path) {
         GraphTargetItem object = stack.pop();
-        stack.push(new DirectValueActionItem(null, 0, new Null(), new ArrayList<String>()));
         stack.push(new EnumerateActionItem(this, object));
     }
 }


### PR DESCRIPTION
...Item, no need to push it on the stack

Pushing Null on the stack will corrupt the stack, causing decompilation errors.
This fixes decompilation of the function bezierMaker/Tweener in issue nr 243 in the issue tracker.
Unit tests are ok.
(Note: Github is showing the diff of the merge in a rather strange way, I only deleted one line in the file which Github is not showing, you can check by viewing the full file.)
