### PR TITLE
ffdec.sh: now relative paths accepted

### DIFF
--- a/resources/ffdec.sh
+++ b/resources/ffdec.sh
@@ -56,9 +56,15 @@ PROGRAM="$0"
 while [ -L "$PROGRAM" ]; do
 	PROGRAM=`readlink -f "$PROGRAM"`
 done
-cd "`dirname \"$PROGRAM\"`"
+pushd "`dirname \"$PROGRAM\"`" > /dev/null
 
 search_jar_file || exit 1
+
+if [ ${JAR_FILE:0:1} != '/' ] ; then
+    JAR_FILE=`pwd`/$JAR_FILE
+fi
+
+popd > /dev/null
 
 # Check default java
 if [ -x "`which java`" ]; then


### PR DESCRIPTION
This patch allows relative paths in CLI interface. For example: 
```Bash
ffdec -export script . ../../../Computer/Programming/Web/video_download/player.swf
```
Previously only absolute paths are accepted bacuase [this line](https://github.com/yan12125/jpexs-decompiler/blob/master/resources/ffdec.sh#L59) changes the working directory.