### PR TITLE
Fix #835 - Static initializer missing

### DIFF
--- a/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/abc/avm2/AVM2Code.java
+++ b/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/abc/avm2/AVM2Code.java
@@ -1645,10 +1645,12 @@ public class AVM2Code implements Cloneable {
                         if (t.name_index == multinameIndex) {
                             if ((t instanceof TraitSlotConst)) {
                                 if (((TraitSlotConst) t).isConst() || isStaticInitializer) {
-                                    ((TraitSlotConst) t).assignedValue = value;
-                                    list.remove(i);
-                                    i--;
-                                    continue;
+                                    if ((((TraitSlotConst) t).assignedValue) == null) {
+                                        ((TraitSlotConst) t).assignedValue = value;
+                                        list.remove(i);
+                                        i--;
+                                        continue;
+                                    }
                                 }
                                 break;
                             }
@@ -1665,9 +1667,7 @@ public class AVM2Code implements Cloneable {
             for (GraphTargetItem ti : list) {
                 if (!(ti instanceof ReturnVoidAVM2Item)) {
                     if (!(ti instanceof InitPropertyAVM2Item)) {
-                        if (!(ti instanceof SetPropertyAVM2Item)) {
-                            newList.add(ti);
-                        }
+                        newList.add(ti);
                     }
                 }
             }


### PR DESCRIPTION
Proposal to fix issue 835. This commit avoids that the class static initializer code is overwriting the initialization of the static variables and avoids deletion of class static initializer code in case it sets a new value for one of the static variables.

A suggestion for further improvement would be to move the static initializer part of the class after the initialization of the static class variables in the decompiled code because the static initializer will execute after the initalization of the static variables.