### PR TITLE
Read at most 5 bytes when reading u32 or u30 (fixes #910)

### DIFF
--- a/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/abc/ABCInputStream.java
+++ b/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/abc/ABCInputStream.java
@@ -182,7 +182,7 @@ public class ABCInputStream implements AutoCloseable {
             ret += (((long) i) << bytePos);
             byteCount++;
             bytePos += 7;
-        } while (nextByte);
+        } while (nextByte && byteCount < 5);
         return ret;
     }
 


### PR DESCRIPTION
As was discussed in the [issue #910](https://www.free-decompiler.com/flash/issues/910), it looks like some obfuscators make improper u32/u30 values which have the most significant bit of the 5th byte set to 1. This causes the bytecode to be read incorrectly.

According to the [documentation](https://wikidocs.adobe.com/wiki/display/AVM2/4.1+Primitive+data+types):
> The variable-length encoding for u30, u32, and s32 uses one to five bytes

Explicitly limiting the number of bytes read to 5 appears to fix the issue.