### PR TITLE
fixed forward slash translation in RegExp

### DIFF
--- a/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/abc/avm2/model/RegExpAvm2Item.java
+++ b/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/abc/avm2/model/RegExpAvm2Item.java
@@ -60,8 +60,6 @@ public class RegExpAvm2Item extends AVM2Item implements Callable {
                 ret.append("\\b");
             } else if (c == '\f') {
                 ret.append("\\f");
-            } else if (c == '/') {
-                ret.append("\\/");
             } else if (c < 32) {
                 ret.append("\\x").append(Helper.byteToHex((byte) c));
             } else {


### PR DESCRIPTION
Instead of `/http:\\/\\//` decompiler should produce `/http:\/\//`.
Escaping `\` IS already in the regexp, as in other case flex wouldnt be able to compile it.

Example where it was failing:

```js
package
{
   public class Util
   {
      public function Util()
      {
         super();
      }

      public static function isURL(param1:String) : Boolean
      {
         var p:RegExp = /^http:\/\//;
         return p.exec(param1) != null;
      }
   }
}
```