### PR TITLE
Fixed current context in closures

### DIFF
--- a/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/abc/avm2/instructions/construction/NewFunctionIns.java
+++ b/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/abc/avm2/instructions/construction/NewFunctionIns.java
@@ -39,7 +39,7 @@ public class NewFunctionIns extends InstructionDefinition {
     @Override
     public void translate(AVM2LocalData localData, TranslateStack stack, AVM2Instruction ins, List<GraphTargetItem> output, String path) {
         int methodIndex = ins.operands[0];
-        NewFunctionAVM2Item function = new NewFunctionAVM2Item(ins, localData.lineStartInstruction, "", path, localData.isStatic, localData.scriptIndex, localData.classIndex, localData.abc, localData.fullyQualifiedNames, methodIndex);
+        NewFunctionAVM2Item function = new NewFunctionAVM2Item(ins, localData.lineStartInstruction, "", path, false, localData.scriptIndex, localData.classIndex, localData.abc, localData.fullyQualifiedNames, methodIndex);
         stack.push(function);
     }
 

--- a/src/com/jpexs/decompiler/flash/gui/MainFrameMenu.java
+++ b/src/com/jpexs/decompiler/flash/gui/MainFrameMenu.java
@@ -882,9 +882,11 @@ public abstract class MainFrameMenu implements MenuBuilder {
         addToggleMenuItem("/tools/timeline", translate("menu.tools.timeline"), null, "timeline32", this::timelineActionPerformed, PRIORITY_TOP, null);
 
         addMenuItem("/tools/showProxy", translate("menu.tools.proxy"), "proxy16", this::showProxyActionPerformed, PRIORITY_MEDIUM, null, true, null, false);
-        addMenuItem("/tools/searchMemory", translate("menu.tools.searchMemory"), "loadmemory16", this::searchMemoryActionPerformed, PRIORITY_MEDIUM, null, true, null, false);
-        //addMenuItem("/tools/searchCache", translate("menu.tools.searchCache"), "loadcache16", this::searchCacheActionPerformed, PRIORITY_MEDIUM, null, true, null);
+        if (Platform.isWindows()) {
+            addMenuItem("/tools/searchMemory", translate("menu.tools.searchMemory"), "loadmemory16", this::searchMemoryActionPerformed, PRIORITY_MEDIUM, null, true, null, false);
+        }
 
+        //addMenuItem("/tools/searchCache", translate("menu.tools.searchCache"), "loadcache16", this::searchCacheActionPerformed, PRIORITY_MEDIUM, null, true, null);
         addMenuItem("/tools/deobfuscation", translate("menu.tools.deobfuscation"), "deobfuscate16", null, 0, null, false, null, false);
         addMenuItem("/tools/deobfuscation/renameOneIdentifier", translate("menu.tools.deobfuscation.globalrename"), "rename16", this::renameOneIdentifier, PRIORITY_MEDIUM, null, true, null, false);
         addMenuItem("/tools/deobfuscation/renameInvalidIdentifiers", translate("menu.tools.deobfuscation.renameinvalid"), "renameall16", this::renameInvalidIdentifiers, PRIORITY_MEDIUM, null, true, null, false);


### PR DESCRIPTION
Closures are NEVER static.

Inside static methods closure body shouldn't have static context because it is applied at runtime upon calling the function.

In provided example `this` inside closure was replaced by Closure. It is not correct.

```js
package
{
   public class Closure
   {
      public function Closure()
      {
         super();
      }

      public static function meth():void
      {
          trace("cool!");
      }
      
      public static function Buggy() : Function
      {
          var f:Function = function():void
	  {
	      this.callee();
	      Closure.meth();
	  }

	  return f;
      }
   }
}
```