### PR TITLE
Fix namespaces

### DIFF
--- a/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/abc/avm2/model/AVM2Item.java
+++ b/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/abc/avm2/model/AVM2Item.java
@@ -108,6 +108,8 @@ public abstract class AVM2Item extends GraphTargetItem {
         }
         if (propertyName instanceof FullMultinameAVM2Item) {
             if (((FullMultinameAVM2Item) propertyName).name != null) {
+                if (((FullMultinameAVM2Item) propertyName).namespace != null)
+                    writer.append(".");
                 return propertyName.toString(writer, localData);
             } else {
                 writer.append(".");

--- a/src/com/jpexs/decompiler/flash/gui/MainFrameMenu.java
+++ b/src/com/jpexs/decompiler/flash/gui/MainFrameMenu.java
@@ -882,9 +882,11 @@ public abstract class MainFrameMenu implements MenuBuilder {
         addToggleMenuItem("/tools/timeline", translate("menu.tools.timeline"), null, "timeline32", this::timelineActionPerformed, PRIORITY_TOP, null);
 
         addMenuItem("/tools/showProxy", translate("menu.tools.proxy"), "proxy16", this::showProxyActionPerformed, PRIORITY_MEDIUM, null, true, null, false);
-        addMenuItem("/tools/searchMemory", translate("menu.tools.searchMemory"), "loadmemory16", this::searchMemoryActionPerformed, PRIORITY_MEDIUM, null, true, null, false);
-        //addMenuItem("/tools/searchCache", translate("menu.tools.searchCache"), "loadcache16", this::searchCacheActionPerformed, PRIORITY_MEDIUM, null, true, null);
+        if (Platform.isWindows()) {
+            addMenuItem("/tools/searchMemory", translate("menu.tools.searchMemory"), "loadmemory16", this::searchMemoryActionPerformed, PRIORITY_MEDIUM, null, true, null, false);
+        }
 
+        //addMenuItem("/tools/searchCache", translate("menu.tools.searchCache"), "loadcache16", this::searchCacheActionPerformed, PRIORITY_MEDIUM, null, true, null);
         addMenuItem("/tools/deobfuscation", translate("menu.tools.deobfuscation"), "deobfuscate16", null, 0, null, false, null, false);
         addMenuItem("/tools/deobfuscation/renameOneIdentifier", translate("menu.tools.deobfuscation.globalrename"), "rename16", this::renameOneIdentifier, PRIORITY_MEDIUM, null, true, null, false);
         addMenuItem("/tools/deobfuscation/renameInvalidIdentifiers", translate("menu.tools.deobfuscation.renameinvalid"), "renameall16", this::renameInvalidIdentifiers, PRIORITY_MEDIUM, null, true, null, false);


### PR DESCRIPTION
If we have such code:

```js
package
{
    public class NS
    {
        public function NS()
        {
            super();
        }

        public function parse(xml:XML):void
        {
            var ns:Namespace = xml.namespace();
            if (xml.ns::body.ns::["switch"] != null)
                trace("hi");
        }
    }
}
```

then `IF` condition becomes:

```js
if(param1._loc2_::body_loc2_::["switch"] != null)
```

Dot after `body` is missing.

This PR fixes this.

Interesting that if condition looks like this:

```js
 if (xml.ns::body.ns::title.text() != null)
```

Then all dots are on correct places.. very different handling of properties..