### PR TITLE
Deobfuscate no-op push instructions

### DIFF
--- a/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/abc/avm2/deobfuscation/AVM2DeobfuscatorSimple.java
+++ b/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/abc/avm2/deobfuscation/AVM2DeobfuscatorSimple.java
@@ -64,11 +64,14 @@ import com.jpexs.decompiler.flash.abc.avm2.instructions.stack.PopIns;
 import com.jpexs.decompiler.flash.abc.avm2.instructions.stack.PushByteIns;
 import com.jpexs.decompiler.flash.abc.avm2.instructions.stack.PushDoubleIns;
 import com.jpexs.decompiler.flash.abc.avm2.instructions.stack.PushFalseIns;
+import com.jpexs.decompiler.flash.abc.avm2.instructions.stack.PushIntegerTypeIns;
 import com.jpexs.decompiler.flash.abc.avm2.instructions.stack.PushIntIns;
+import com.jpexs.decompiler.flash.abc.avm2.instructions.stack.PushNanIns;
 import com.jpexs.decompiler.flash.abc.avm2.instructions.stack.PushNullIns;
 import com.jpexs.decompiler.flash.abc.avm2.instructions.stack.PushShortIns;
 import com.jpexs.decompiler.flash.abc.avm2.instructions.stack.PushStringIns;
 import com.jpexs.decompiler.flash.abc.avm2.instructions.stack.PushTrueIns;
+import com.jpexs.decompiler.flash.abc.avm2.instructions.stack.PushUIntIns;
 import com.jpexs.decompiler.flash.abc.avm2.instructions.stack.PushUndefinedIns;
 import com.jpexs.decompiler.flash.abc.avm2.instructions.stack.SwapIns;
 import com.jpexs.decompiler.flash.abc.avm2.instructions.types.CoerceOrConvertTypeIns;
@@ -146,6 +149,37 @@ public class AVM2DeobfuscatorSimple extends SWFDecompilerAdapter {
             }
         }
         return result;
+    }
+
+    protected boolean removeNullPushes(AVM2Code code, MethodBody body) throws InterruptedException {
+        boolean result = false;
+        // Deliberately skip over instruction zero
+        for(int i = 1; i < code.code.size(); i++) {
+            AVM2Instruction ins1 = code.code.get(i - 1);
+            AVM2Instruction ins2 = code.code.get(i);
+            if(ins2.definition instanceof PopIns &&
+                (ins1.definition instanceof PushByteIns ||
+                ins1.definition instanceof PushDoubleIns ||
+                ins1.definition instanceof PushFalseIns ||
+                ins1.definition instanceof PushIntIns ||
+                ins1.definition instanceof PushIntegerTypeIns ||
+                ins1.definition instanceof PushNanIns ||
+                ins1.definition instanceof PushNullIns ||
+                ins1.definition instanceof PushShortIns ||
+                ins1.definition instanceof PushStringIns ||
+                ins1.definition instanceof PushTrueIns ||
+                ins1.definition instanceof PushUIntIns ||
+                ins1.definition instanceof PushUndefinedIns)
+            ) {
+                if (Thread.currentThread().isInterrupted()) {
+                    throw new InterruptedException();
+                }
+
+                code.removeInstruction(i - 1, body); i--;
+                code.removeInstruction(i, body); i--;
+                result = true;
+            }
+        } return result;
     }
 
     protected void initLocalRegs(LocalDataArea localData, int localReservedCount, int maxRegs, boolean executeFromFirst) {
@@ -374,6 +408,7 @@ public class AVM2DeobfuscatorSimple extends SWFDecompilerAdapter {
         code.removeDeadCode(body);
         removeObfuscationIfs(classIndex, isStatic, scriptIndex, abc, body, null);
         removeZeroJumps(code, body);
+        removeNullPushes(code, body);
     }
 
     class ExecutionResult {

--- a/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/abc/avm2/deobfuscation/AVM2DeobfuscatorSimple.java
+++ b/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/abc/avm2/deobfuscation/AVM2DeobfuscatorSimple.java
@@ -155,9 +155,11 @@ public class AVM2DeobfuscatorSimple extends SWFDecompilerAdapter {
         boolean result = false;
         // Deliberately skip over instruction zero
         for(int i = 1; i < code.code.size(); i++) {
+            Set<Long> offsets = code.getImportantOffsets(body, true);
             AVM2Instruction ins1 = code.code.get(i - 1);
             AVM2Instruction ins2 = code.code.get(i);
             if(ins2.definition instanceof PopIns &&
+                !offsets.contains(ins2.getAddress()) &&
                 (ins1.definition instanceof PushByteIns ||
                 ins1.definition instanceof PushDoubleIns ||
                 ins1.definition instanceof PushFalseIns ||

--- a/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/abc/avm2/deobfuscation/AVM2DeobfuscatorSimpleOld.java
+++ b/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/abc/avm2/deobfuscation/AVM2DeobfuscatorSimpleOld.java
@@ -105,6 +105,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  *
@@ -210,9 +211,11 @@ public class AVM2DeobfuscatorSimpleOld extends SWFDecompilerAdapter {
         boolean result = false;
         // Deliberately skip over instruction zero
         for(int i = 1; i < code.code.size(); i++) {
+            Set<Long> offsets = code.getImportantOffsets(body, true);
             AVM2Instruction ins1 = code.code.get(i - 1);
             AVM2Instruction ins2 = code.code.get(i);
             if(ins2.definition instanceof PopIns &&
+                !offsets.contains(ins2.getAddress()) &&
                 (ins1.definition instanceof PushByteIns ||
                 ins1.definition instanceof PushDoubleIns ||
                 ins1.definition instanceof PushFalseIns ||


### PR DESCRIPTION
Some obfuscators will scatter the instructions:

```
pushtrue
pop
```

or:

```
pushfalse
pop
```

randomly throughout the P-code. As any `pushxxx` instruction immediately followed by a `pop` instruction must be a no-op, they should be removed.