### PR TITLE
Prevent crash when calling insertInstruction() on empty MethodBody

### DIFF
--- a/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/abc/avm2/AVM2Code.java
+++ b/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/abc/avm2/AVM2Code.java
@@ -2371,7 +2371,9 @@ public class AVM2Code implements Cloneable {
             pos = code.size();
         }
         final int byteCount = instruction.getBytesLength();
-        if (pos == code.size()) {
+        if (code.size() == 0) {
+            instruction.setAddress(0);
+        } else if (pos == code.size()) {
             instruction.setAddress(code.get(pos - 1).getAddress() + code.get(pos - 1).getBytesLength());
         } else {
             instruction.setAddress(code.get(pos).getAddress());


### PR DESCRIPTION
If an `AVM2Code` instance is empty, and we attempt to insert an instruction, the method will call `code.get(-1)` and throw an exception. This commit handles the situation.