### PR TITLE
export feColorMatrix in SVG export

### DIFF
--- a/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/exporters/shape/SVGShapeExporter.java
+++ b/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/exporters/shape/SVGShapeExporter.java
@@ -44,6 +44,8 @@ public class SVGShapeExporter extends DefaultSVGShapeExporter {
 
     protected int lastPatternId;
 
+    protected int lastFilterId;
+
     private final Color defaultColor;
 
     private final SWF swf;
@@ -106,6 +108,25 @@ public class SVGShapeExporter extends DefaultSVGShapeExporter {
             if (img != null) {
                 if (colorTransform != null) {
                     colorTransform.apply(img);
+                }
+                if (colorTransform != null){
+                    lastFilterId++;
+                    String filterId = "FilterID_";
+                    filterId += lastFilterId;
+                    Element filter = exporter.createElement("filter");
+                    filter.setAttribute("id", filterId);
+                    Element feColorMatrix = exporter.createElement("feColorMatrix");
+                    feColorMatrix.setAttribute("in", "SourceGraphic");
+                    feColorMatrix.setAttribute("type", "matrix");
+                    feColorMatrix.setAttribute("values", "" +
+                            colorTransform.getRedMulti() + " 0 0 0 " + colorTransform.getRedAdd() + ", " +
+                            "0 " + colorTransform.getGreenMulti() + " 0 0 " + colorTransform.getGreenAdd() + ", " +
+                            "0 0 " + colorTransform.getBlueMulti() + " 0 " + colorTransform.getBlueAdd() + ", " +
+                            "0 0 0 " + colorTransform.getAlphaMulti() + " " + colorTransform.getAlphaAdd());
+
+                    filter.appendChild(feColorMatrix);
+                    exporter.addToGroup(filter);
+                    path.setAttribute("filter", "url(#" + filterId + ")");
                 }
 
                 int width = img.getWidth();


### PR DESCRIPTION
Exporting SVG frames that have layers with color transforms do not seem to apply them. 

SVG has an element that will apply color transforms though 
https://developer.mozilla.org/en-US/docs/Web/SVG/Element/feColorMatrix

This code applies color transforms to those layers in the SVG output.

I have placed the code here as I believe the above lines are meant to apply these changes, but they don't seem to work for me. 

Some of this new code may be better in other classes. It's just a demonstration of the issue and a fix, not the best solution to it.

The example file is https://github.com/tinyspeck/glitch-avatars/blob/master/base_avatar/Avatar.swf

DefineSprite 409("avatarContainer"), frame 1. The PlaceObject2 tags that named begin with "back"* include colorTransforms. 

To see the feature, compare the svg and png output of exporting frame 1 before this patch, and after.

n.b: this patch seems to not apply the color transforms correctly. I'm posting it anyway to see if the developers have any ideas why the original behaviour for color transforms doesn't work for svg, or why this patch doesn't work correctly.