### PR TITLE
Prevent impossible pushshort pcode generation on direct edit actionscript

### DIFF
--- a/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/abc/avm2/model/IntegerValueAVM2Item.java
+++ b/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/abc/avm2/model/IntegerValueAVM2Item.java
@@ -137,7 +137,7 @@ public class IntegerValueAVM2Item extends NumberValueAVM2Item implements Integer
         if (value >= -128 && value <= 127) {
             ins = new AVM2Instruction(0, AVM2Instructions.PushByte, new int[]{(int) (long) value});
         } else if (value >= -32768 && value <= 32767) {
-            ins = new AVM2Instruction(0, AVM2Instructions.PushShort, new int[]{((int) (long) value) & 0xffff});
+            ins = new AVM2Instruction(0, AVM2Instructions.PushShort, new int[]{((int) (long) value)});
         } else {
             ins = new AVM2Instruction(0, AVM2Instructions.PushInt, new int[]{((AVM2SourceGenerator) generator).abcIndex.getSelectedAbc().constants.getIntId(value, true)});
         }


### PR DESCRIPTION
Directly editing the actionscript of an swf file and writing a simple variable assignment with a negative short value literal (or if there is such assignment in the file anywhere) will generate invalid P-code.
For example:
static var k = -200;
generated:
pushshort 65336

If the P-code is edited afterwards, it throws an error when trying to save it, saying that pushshort has a valid range of -32768 to 32767

This pull request simply removes the seemingly unnecessary masking of the value which flips the negative values.