### PR TITLE
Debug tooltips on hover

### DIFF
--- a/src/com/jpexs/decompiler/flash/gui/DebugPanel.java
+++ b/src/com/jpexs/decompiler/flash/gui/DebugPanel.java
@@ -85,6 +85,8 @@ public class DebugPanel extends JPanel {
 
     private boolean loading = false;
 
+    public ABCPanel.VariablesTableModel localsTable;
+    
     public static enum SelectedTab {
 
         LOG, STACK, SCOPECHAIN, LOCALS, REGISTERS, CALLSTACK, CONSTANTPOOL
@@ -346,6 +348,7 @@ public class DebugPanel extends JPanel {
                 synchronized (DebugPanel.this) {
 
                     SelectedTab oldSel = selectedTab;
+                    localsTable = null;
                     InFrame f = Main.getDebugHandler().getFrame();
                     if (f != null) {
 
@@ -362,7 +365,8 @@ public class DebugPanel extends JPanel {
                         localIds.addAll(f.argumentFrameIds);
                         localIds.addAll(f.frameIds);
 
-                        safeSetTreeModel(debugLocalsTable, new ABCPanel.VariablesTableModel(debugLocalsTable, locals, localIds));
+                        localsTable = new ABCPanel.VariablesTableModel(debugLocalsTable, locals, localIds);
+                        safeSetTreeModel(debugLocalsTable, localsTable);
                         safeSetTreeModel(debugScopeTable, new ABCPanel.VariablesTableModel(debugScopeTable, f.scopeChain, f.scopeChainFrameIds));
 
                         /*TableModelListener refreshListener = new TableModelListener() {

--- a/src/com/jpexs/decompiler/flash/gui/MainPanel.java
+++ b/src/com/jpexs/decompiler/flash/gui/MainPanel.java
@@ -823,7 +823,7 @@ public final class MainPanel extends JPanel implements TreeSelectionListener, Se
         return abcPanel;
     }
 
-    private ActionPanel getActionPanel() {
+    public ActionPanel getActionPanel() {
         if (actionPanel == null) {
             actionPanel = new ActionPanel(MainPanel.this);
             displayPanel.add(actionPanel, CARDACTIONSCRIPTPANEL);

--- a/src/com/jpexs/decompiler/flash/gui/abc/DecompiledEditorPane.java
+++ b/src/com/jpexs/decompiler/flash/gui/abc/DecompiledEditorPane.java
@@ -46,6 +46,7 @@ import com.jpexs.decompiler.flash.tags.ABCContainerTag;
 import com.jpexs.decompiler.graph.DottedChain;
 import com.jpexs.helpers.CancellableWorker;
 import java.awt.Point;
+import java.awt.event.MouseEvent;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Timer;
@@ -788,5 +789,25 @@ public class DecompiledEditorPane extends DebuggableEditorPane implements CaretL
     public void setText(String t) {
         super.setText(t);
         setCaretPosition(0);
+    }
+
+    @Override
+    public String getToolTipText(MouseEvent e) {    
+        // not debugging: so return existing text
+        if (abcPanel.getDebugPanel().localsTable == null)
+           return super.getToolTipText();
+                
+        final Point point       = new Point(e.getX(), e.getY());
+        final int pos           = abcPanel.decompiledTextArea.viewToModel(point);
+        final String identifier = abcPanel.getMainPanel().getActionPanel().getStringUnderPosition(pos, abcPanel.decompiledTextArea);
+
+        if (identifier != null && !identifier.isEmpty())
+        {
+            String tooltipText = abcPanel.getDebugPanel().localsTable.TryGetDebugHoverToolTipText(identifier);
+            return (tooltipText == null ? super.getToolTipText() : tooltipText);
+        }
+        
+        // not found: so return existing text
+        return super.getToolTipText();
     }
 }

--- a/src/com/jpexs/decompiler/flash/gui/action/ActionPanel.java
+++ b/src/com/jpexs/decompiler/flash/gui/action/ActionPanel.java
@@ -84,6 +84,7 @@ import javax.swing.SwingConstants;
 import javax.swing.event.CaretEvent;
 import javax.swing.event.CaretListener;
 import javax.swing.text.Highlighter;
+import javax.swing.text.JTextComponent;
 import javax.swing.tree.TreePath;
 import jsyntaxpane.SyntaxDocument;
 import jsyntaxpane.Token;
@@ -182,10 +183,12 @@ public class ActionPanel extends JPanel implements SearchListener<ActionSearchRe
 
     public String getStringUnderCursor() {
         View.checkAccess();
-
         int pos = decompiledEditor.getCaretPosition();
-
-        SyntaxDocument sDoc = ActionUtils.getSyntaxDocument(decompiledEditor);
+        return getStringUnderPosition(pos, decompiledEditor);
+    }
+    
+    public String getStringUnderPosition(int pos, JTextComponent component) {
+        SyntaxDocument sDoc = ActionUtils.getSyntaxDocument(component);
         if (sDoc != null) {
             Token t = sDoc.getTokenAt(pos + 1);
             String ident = null;


### PR DESCRIPTION
When in Debug mode and stopped at a breakpoint, hovering over identifiers will show up their name and value in a tooltip. All matching locals will be shown, one on each line. This makes the debugging experience a lot more interactive and useful.