### PR TITLE
It's possible to send arguments to FFDec using `open` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 ### Added
+- Possibility to open SWF files using open on Mac
+
+### Added
 - updated turkish translation
 
 ### Fixed

--- a/build.xml
+++ b/build.xml
@@ -323,7 +323,7 @@
     
     <target name="osx-app-bundle" depends="-loadversion,dist">
         <property name="app.script.temp" value="${app.bundle.dir}/${app.osx.dir}.app/Contents/MacOS/${app.osx.dir}"/>
-        <echo file="${app.script.temp}">#!/bin/bash&#10;cd "$(dirname "$${BASH_SOURCE[0]}")"&#10;cd ../Resources&#10;./${app.script}</echo>
+        <echo file="${app.script.temp}">#!/bin/bash&#10;$(dirname "$${BASH_SOURCE[0]}")/../Resources/${app.script} "$$&#64;"</echo>
         <property name="app.info.temp" value="${app.bundle.dir}/${app.osx.dir}.app/Contents/Info.plist"/>
         <echo file="${app.info.temp}"><![CDATA[<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">


### PR DESCRIPTION
Example:
`open -a ffdec --args "~/file.swf"`

However, this is not going to work:
`open -a ffdec file.swf`
but that's because of how shell scripts work on OS X.