### PR TITLE
NPE on runtime when installedFontsByFamily is `null`

### DIFF
--- a/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/tags/base/FontTag.java
+++ b/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/tags/base/FontTag.java
@@ -306,12 +306,12 @@ public abstract class FontTag extends DrawableTag implements AloneTag {
     }
 
     public static String isFontFamilyInstalled(String fontFamily) {
-        if (installedFontsByFamily.containsKey(fontFamily)) {
+        if (installedFontsByFamily != null && installedFontsByFamily.containsKey(fontFamily)) {
             return fontFamily;
         }
         if (fontFamily.contains("_")) {
             String beforeUnderscore = fontFamily.substring(0, fontFamily.indexOf('_'));
-            if (installedFontsByFamily.containsKey(beforeUnderscore)) {
+            if (installedFontsByFamily != null && installedFontsByFamily.containsKey(beforeUnderscore)) {
                 return beforeUnderscore;
             }
         }

--- a/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/tags/base/FontTag.java
+++ b/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/tags/base/FontTag.java
@@ -306,12 +306,13 @@ public abstract class FontTag extends DrawableTag implements AloneTag {
     }
 
     public static String isFontFamilyInstalled(String fontFamily) {
-        if (installedFontsByFamily != null && installedFontsByFamily.containsKey(fontFamily)) {
+        ensureLoaded();
+        if (installedFontsByFamily.containsKey(fontFamily)) {
             return fontFamily;
         }
         if (fontFamily.contains("_")) {
             String beforeUnderscore = fontFamily.substring(0, fontFamily.indexOf('_'));
-            if (installedFontsByFamily != null && installedFontsByFamily.containsKey(beforeUnderscore)) {
+            if (installedFontsByFamily.containsKey(beforeUnderscore)) {
                 return beforeUnderscore;
             }
         }


### PR DESCRIPTION
When running the command `java -jar dist/ffdec.jar -export fla <out> <file.swf>`, it crashes with stacktrace:
```
java.lang.NullPointerException                                                                                                                                                                                                                                           
        at com.jpexs.decompiler.flash.tags.base.FontTag.isFontFamilyInstalled(FontTag.java:310)                                                                                                                                                                          
        at com.jpexs.decompiler.flash.xfl.XFLConverter.convertFonts(XFLConverter.java:2366)                                                                                                                                                                              
        at com.jpexs.decompiler.flash.xfl.XFLConverter.convertSWF(XFLConverter.java:3363)
        at com.jpexs.decompiler.flash.SWF.exportXfl(SWF.java:2506)
        at com.jpexs.decompiler.flash.console.CommandLineArgumentParser.exportFla(CommandLineArgumentParser.java:2410)
        at com.jpexs.decompiler.flash.console.CommandLineArgumentParser.parseExport(CommandLineArgumentParser.java:2349)
        at com.jpexs.decompiler.flash.console.CommandLineArgumentParser.parseArguments(CommandLineArgumentParser.java:891)
        at com.jpexs.decompiler.flash.gui.Main.main(Main.java:1976)

```

Null checking `installedFontsByFamily` fixes the issue and the SWF to FLA is successful.