### PR TITLE
invalid generation of lookupswitch

### DIFF
--- a/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/abc/avm2/parser/script/AVM2SourceGenerator.java
+++ b/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/abc/avm2/parser/script/AVM2SourceGenerator.java
@@ -661,7 +661,7 @@ public class AVM2SourceGenerator implements SourceGenerator {
             bodiesOffsets.add(0, -(insToBytes(bodies).length + casesLen));
         }
         lookupOp.operands[0] = defOffset;
-        lookupOp.operands[1] = item.valuesMapping.size();
+        lookupOp.operands[1] = item.valuesMapping.size() - 1; // as per avm2 spec: "There are case_count+1 case offsets"
         for (int i = 0; i < item.valuesMapping.size(); i++) {
             lookupOp.operands[2 + i] = bodiesOffsets.get(item.valuesMapping.get(i));
         }


### PR DESCRIPTION
The [spec](https://www.adobe.com/content/dam/acom/en/devnet/pdf/avm2overview.pdf) for the p-code `lookupswitch` says: 

> There are case_count+1 case offsets.

The previous implementation in `AVM2SourceGenerator` did not respect this. To reproduce just edit any as3 with a switch and in the p-code you will get something like this:
``lookupswitch ofs0049 3 ofs002c ofs0037 ofs0042``
This will raise an error when you execute it. Also when you try to edit the p-code in ffdec (without changing anything) you will get an error because of the wrong `case_count`.
Now with my change this p-code is generated:
``lookupswitch ofs0049 2 ofs002c ofs0037 ofs0042``