### PR TITLE
Fix access to protected members with super

### DIFF
--- a/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/abc/avm2/parser/script/AVM2SourceGenerator.java
+++ b/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/abc/avm2/parser/script/AVM2SourceGenerator.java
@@ -2516,18 +2516,20 @@ public class AVM2SourceGenerator implements SourceGenerator {
     }
 
     public static boolean searchPrototypeChain(List<Integer> otherNs, int privateNs, int protectedNs, boolean instanceOnly, AbcIndexing abc, DottedChain pkg, String obj, String propertyName, Reference<String> outName, Reference<DottedChain> outNs, Reference<DottedChain> outPropNs, Reference<Integer> outPropNsKind, Reference<Integer> outPropNsIndex, Reference<GraphTargetItem> outPropType, Reference<ValueKind> outPropValue, Reference<ABC> outPropValueAbc) {
-        for (int ns : otherNs) {
-            if (searchPrototypeChain(ns, instanceOnly, abc, pkg, obj, propertyName, outName, outNs, outPropNs, outPropNsKind, outPropNsIndex, outPropType, outPropValue, outPropValueAbc)) {
-                return true;
-            }
-        }
-
+        // private and protected namespaces first so we find overriding functions before overridden functions
         if (searchPrototypeChain(privateNs, instanceOnly, abc, pkg, obj, propertyName, outName, outNs, outPropNs, outPropNsKind, outPropNsIndex, outPropType, outPropValue, outPropValueAbc)) {
             return true;
         }
         if (searchPrototypeChain(protectedNs, instanceOnly, abc, pkg, obj, propertyName, outName, outNs, outPropNs, outPropNsKind, outPropNsIndex, outPropType, outPropValue, outPropValueAbc)) {
             return true;
         }
+
+        for (int ns : otherNs) {
+            if (searchPrototypeChain(ns, instanceOnly, abc, pkg, obj, propertyName, outName, outNs, outPropNs, outPropNsKind, outPropNsIndex, outPropType, outPropValue, outPropValueAbc)) {
+                return true;
+            }
+        }
+
         return searchPrototypeChain(0, instanceOnly, abc, pkg, obj, propertyName, outName, outNs, outPropNs, outPropNsKind, outPropNsIndex, outPropType, outPropValue, outPropValueAbc);
     }
 


### PR DESCRIPTION
If you have these classes:
```
public class A { 
    protected function protectedFun(): String {
        return "from A";
    }  
}
```
```
public class B extends A {
    override protected function protectedFun():String {
        return super.protectedFun();
    }
    public function getStr(): String {
        return this.protectedFun();
    }
}
```
For the `B.protectedFun` the flash compiler will generate p-code including:
`callsuper Qname(ProtectedNamespace("A"),"protectedFun") 0`
For the `B.getStr` the flash compiler will generate p-code including:
`callproperty Qname(ProtectedNamespace("B"),"protectedFun") 0`

Now if you direct edit the `B` class (just adding an empty line or so) ffdec will compile:
`B.protectedFun`: 
`callsuper Multiname("protectedFun",[PackageNamespace(""),Namespace("http://adobe.c, ...]) 0`
`B.getStr`: 
`callproperty Qname(ProtectedNamespace("A"),"protectedFun") 0`

While the later one still works, it's odd. However the `Multiname` stuff does not work and will crash flash.
You can reproduce this with [this swf](https://github.com/jindrapetrik/jpexs-decompiler/files/3099130/protected-super-acess.zip). It should show "from A" when you run it, but if you recompile/direct-edit the `B` class using ffdec it will show nothing, cause the super call fails.

I also added a fix to the `searchPrototypeChain` function so that the `B.getStr` function compiles to the same as the flash compiler.