### PR TITLE
Negative focal point deserialization

### DIFF
--- a/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/SWFInputStream.java
+++ b/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/SWFInputStream.java
@@ -675,12 +675,7 @@ public class SWFInputStream implements AutoCloseable {
         newDumpLevel(name, "FIXED8");
         int afterPoint = readEx();
         int beforePoint = readSI8Internal();
-        float ret;
-        if (beforePoint < 0) {
-            ret = beforePoint - ((float) afterPoint) / 256;
-        } else {
-            ret = beforePoint + ((float) afterPoint) / 256;
-        }
+        float ret = beforePoint + ((float) afterPoint) / 256;
         endDumpLevel(ret);
         return ret;
     }

--- a/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/SWFOutputStream.java
+++ b/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/SWFOutputStream.java
@@ -312,9 +312,9 @@ public class SWFOutputStream extends OutputStream {
      * @throws IOException
      */
     public void writeFIXED8(float value) throws IOException {
-        final int divisor = 1 << 8;
-        int beforePoint = (int) value;
-        int afterPoint = Math.abs((int) (value * divisor)) % divisor;
+        int valueInt = (int) (value * (1 << 8));
+        int beforePoint = (int) valueInt >> 8;
+        int afterPoint = (int) valueInt % (1 << 8);
         writeUI8(afterPoint);
         writeSI8(beforePoint);
     }


### PR DESCRIPTION
I found negative focalPoints on radial gradients were being deserialized incorrectly.  The swf spec has them bound between -1 and 1 yet all values from -1 to 0 were instead showing up in the range of -2 to -1

I made an example series of focal gradients from the minimum -1 to the maximum of -1.  The following are the results of the previous and new function:

Before:
     [java] deserializing name:focalPoint (beforePoint:-1, afterPoint:1) => ret:-1.0039062
     [java] deserializing name:focalPoint (beforePoint:-1, afterPoint:36) => ret:-1.140625
     [java] deserializing name:focalPoint (beforePoint:-1, afterPoint:82) => ret:-1.3203125
     [java] deserializing name:focalPoint (beforePoint:-1, afterPoint:101) => ret:-1.3945312
     [java] deserializing name:focalPoint (beforePoint:-1, afterPoint:115) => ret:-1.4492188
     [java] deserializing name:focalPoint (beforePoint:-1, afterPoint:129) => ret:-1.5039062
     [java] deserializing name:focalPoint (beforePoint:-1, afterPoint:148) => ret:-1.578125
     [java] deserializing name:focalPoint (beforePoint:-1, afterPoint:180) => ret:-1.703125
     [java] deserializing name:focalPoint (beforePoint:-1, afterPoint:247) => ret:-1.9648438
     [java] deserializing name:focalPoint (beforePoint:-1, afterPoint:255) => ret:-1.9960938
     [java] deserializing name:focalPoint (beforePoint:0, afterPoint:12) => ret:0.046875
     [java] deserializing name:focalPoint (beforePoint:0, afterPoint:120) => ret:0.46875
     [java] deserializing name:focalPoint (beforePoint:0, afterPoint:98) => ret:0.3828125
     [java] deserializing name:focalPoint (beforePoint:0, afterPoint:255) => ret:0.99609375
After:
     [java] deserializing name:focalPoint (beforePoint:-1, afterPoint:1) => ret:-0.99609375
     [java] deserializing name:focalPoint (beforePoint:-1, afterPoint:36) => ret:-0.859375
     [java] deserializing name:focalPoint (beforePoint:-1, afterPoint:82) => ret:-0.6796875
     [java] deserializing name:focalPoint (beforePoint:-1, afterPoint:101) => ret:-0.60546875
     [java] deserializing name:focalPoint (beforePoint:-1, afterPoint:115) => ret:-0.55078125
     [java] deserializing name:focalPoint (beforePoint:-1, afterPoint:129) => ret:-0.49609375
     [java] deserializing name:focalPoint (beforePoint:-1, afterPoint:148) => ret:-0.421875
     [java] deserializing name:focalPoint (beforePoint:-1, afterPoint:180) => ret:-0.296875
     [java] deserializing name:focalPoint (beforePoint:-1, afterPoint:247) => ret:-0.03515625
     [java] deserializing name:focalPoint (beforePoint:-1, afterPoint:255) => ret:-0.00390625
     [java] deserializing name:focalPoint (beforePoint:0, afterPoint:12) => ret:0.046875
     [java] deserializing name:focalPoint (beforePoint:0, afterPoint:120) => ret:0.46875
     [java] deserializing name:focalPoint (beforePoint:0, afterPoint:98) => ret:0.3828125
     [java] deserializing name:focalPoint (beforePoint:0, afterPoint:255) => ret:0.99609375