### PR TITLE
Try loading .gfx files if .swf failed to load

### DIFF
--- a/src/com/jpexs/decompiler/flash/gui/Main.java
+++ b/src/com/jpexs/decompiler/flash/gui/Main.java
@@ -875,12 +875,23 @@ public class Main {
                                     //ignore
                                 }
                             } else {
-                                File f = new File(new File(file).getParentFile(), url);
-                                if (f.exists()) {
+                                File swf = new File(new File(file).getParentFile(), url);
+                                if (swf.exists()) {
                                     try {
-                                        return open(new FileInputStream(f), f.getAbsolutePath(), f.getName());
+                                        return open(new FileInputStream(swf), swf.getAbsolutePath(), swf.getName());
                                     } catch (Exception ex) {
                                         //ignore
+                                    }
+                                }
+                                // try .gfx if .swf failed
+                                if (url.endsWith(".swf")) {
+                                    File gfx = new File(new File(file).getParentFile(), url.substring(0, url.length()-4)+".gfx");
+                                    if (gfx.exists()) {
+                                        try {
+                                            return open(new FileInputStream(gfx), gfx.getAbsolutePath(), gfx.getName());
+                                        } catch (Exception ex) {
+                                            //ignore
+                                        }
                                     }
                                 }
                             }


### PR DESCRIPTION
The .gfx files I'm working with specify their imports via the paths of the .swf files that they were presumably converted from. The game I'm working with only has .gfx, and seems to replace the .swf file extension with the .gfx extension when loading imports. To avoid having to manually select the right file, I added this behavior to the URL resolver as a fallback if the .swf fails to load.