### PR TITLE
Fix copyStream bug for copies smaller than the buffer size

### DIFF
--- a/libsrc/ffdec_lib/src/com/jpexs/helpers/Helper.java
+++ b/libsrc/ffdec_lib/src/com/jpexs/helpers/Helper.java
@@ -12,7 +12,8 @@
  * Lesser General Public License for more details.
  * 
  * You should have received a copy of the GNU Lesser General Public
- * License along with this library. */
+ * License along with this library.
+ */
 package com.jpexs.helpers;
 
 import com.jpexs.decompiler.flash.AppResources;
@@ -730,15 +731,18 @@ public class Helper {
         try {
             final int bufSize = 4096;
             byte[] buf = new byte[bufSize];
+            int chunkSize = bufSize;
             int cnt = 0;
-            while ((cnt = is.read(buf)) > 0) {
+            while (maxLength > 0) {
+                if (maxLength < bufSize) {
+                    chunkSize = (int) maxLength;
+                }
+                cnt = is.read(buf, 0, chunkSize);
+                if (cnt <= 0) {
+                    break;
+                }
                 os.write(buf, 0, cnt);
                 maxLength -= cnt;
-
-                // last chunk is smaller
-                if (maxLength < bufSize) {
-                    buf = new byte[(int) maxLength];
-                }
             }
         } catch (IOException ex) {
             // ignore


### PR DESCRIPTION
The `copyStream` helper function seems to have a bug that results in a `NegativeArraySizeException` when trying to copy a buffer with a `maxLength` less than `bufSize`. This makes the decompiler unable to load very small flash files (< ca. 500 bytes). I fixed the bug so the function always copies correctly, and also no longer allocates a new buffer for the last chunk.

Sample file that fails to load:

[fehelpscreen_backdrop.zip](https://github.com/jindrapetrik/jpexs-decompiler/files/6549159/fehelpscreen_backdrop.zip)
