### PR TITLE
MainPanel: TagTreeSearch: Remove unnecessary call to doFilter() 

### DIFF
--- a/src/com/jpexs/decompiler/flash/gui/MainPanel.java
+++ b/src/com/jpexs/decompiler/flash/gui/MainPanel.java
@@ -825,7 +825,6 @@ public final class MainPanel extends JPanel implements TreeSelectionListener, Se
         View.checkAccess();
 
         filterField.setText("");
-        doFilter();
         searchPanel.setVisible(false);
     }
 


### PR DESCRIPTION
doFilter() is already executed when the filterField text is updated, so calling it twice should be unnecessary