### PR TITLE
Fix PlayerControls frame display 

### DIFF
--- a/src/com/jpexs/decompiler/flash/gui/player/PlayerControls.java
+++ b/src/com/jpexs/decompiler/flash/gui/player/PlayerControls.java
@@ -213,7 +213,7 @@ public class PlayerControls extends JPanel implements MediaDisplayListener {
             public void mouseClicked(MouseEvent e) {
                 int gotoFrame = PlayerControls.this.display.getCurrentFrame();
                 if (gotoFrame > 0) {
-                    mainPanel.gotoFrame(gotoFrame);
+                    mainPanel.gotoFrame(gotoFrame - 1);
                 }
             }
         });


### PR DESCRIPTION
Now redirects to the current frame instead of the next frame