### PR TITLE
Fixed Incorrect position in Flash Player preview and SWF export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 - AS3 - direct editation - call on local register
 - AS3 - direct editation - resolve properties and local regs before types
 - AS3 - direct editation - call on index
+- Incorrect position in Flash Player preview and SWF export
 
 ## [15.0.0] - 2021-11-29
 ### Added

--- a/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/exporters/PreviewExporter.java
+++ b/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/exporters/PreviewExporter.java
@@ -435,8 +435,8 @@ public class PreviewExporter {
                     RECT r = ((BoundedTag) treeItem).getRect();
                     rxmin = r.Xmin;
                     rymin = r.Ymin;
-                    /*mat.translateX = -r.Xmin;
-                    mat.translateY = -r.Ymin;*/
+                    mat.translateX = -r.Xmin;
+                    mat.translateY = -r.Ymin;
                     mat.translateX = mat.translateX + width / 2 - r.getWidth() / 2;
                     mat.translateY = mat.translateY + (showControls ? height - progressBarHeight * 20 : height) / 2 - r.getHeight() / 2;
                 } else {


### PR DESCRIPTION
Some elements in the view not placed in the center of work space and can going out of it. Under "Flash Player preview" I mean deprecated ActiveX viewer in the application