### PR TITLE
Add support for loading external images in DefineExternalImage2, DefineSubImage

### DIFF
--- a/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/tags/gfx/DefineSubImage.java
+++ b/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/tags/gfx/DefineSubImage.java
@@ -12,26 +12,37 @@
  * Lesser General Public License for more details.
  * 
  * You should have received a copy of the GNU Lesser General Public
- * License along with this library. */
+ * License along with this library.
+ */
 package com.jpexs.decompiler.flash.tags.gfx;
 
 import com.jpexs.decompiler.flash.SWFInputStream;
 import com.jpexs.decompiler.flash.SWFOutputStream;
-import com.jpexs.decompiler.flash.tags.Tag;
+import com.jpexs.decompiler.flash.helpers.ImageHelper;
+import com.jpexs.decompiler.flash.tags.base.ImageTag;
+import com.jpexs.decompiler.flash.tags.enums.ImageFormat;
+import com.jpexs.decompiler.flash.types.annotations.HideInRawEdit;
 import com.jpexs.helpers.ByteArrayRange;
+import com.jpexs.helpers.SerializableImage;
+import java.awt.Dimension;
+import java.awt.Image;
+import java.awt.image.BufferedImage;
 import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import net.npe.dds.DDSReader;
 
 /**
  *
  * @author JPEXS
  */
-public class DefineSubImage extends Tag {
+public class DefineSubImage extends ImageTag {
 
     public static final int ID = 1008;
 
     public static final String NAME = "DefineSubImage";
-
-    public int characterId;
 
     public int imageCharacterId;
 
@@ -42,6 +53,9 @@ public class DefineSubImage extends Tag {
     public int x2;
 
     public int y2;
+    
+    @HideInRawEdit
+    private SerializableImage serImage;
 
     /**
      * Gets data bytes
@@ -51,7 +65,7 @@ public class DefineSubImage extends Tag {
      */
     @Override
     public void getData(SWFOutputStream sos) throws IOException {
-        sos.writeUI16(characterId);
+        sos.writeUI16(characterID);
         sos.writeUI16(imageCharacterId);
         sos.writeUI16(x1);
         sos.writeUI16(y1);
@@ -73,11 +87,61 @@ public class DefineSubImage extends Tag {
 
     @Override
     public final void readData(SWFInputStream sis, ByteArrayRange data, int level, boolean parallel, boolean skipUnusualTags, boolean lazy) throws IOException {
-        characterId = sis.readUI16("characterId");
+        characterID = sis.readUI16("characterID");
         imageCharacterId = sis.readUI16("imageCharacterId");
         x1 = sis.readUI16("x1");
         y1 = sis.readUI16("y1");
         x2 = sis.readUI16("x2");
         y2 = sis.readUI16("y2");
+    }
+    
+    @Override
+    public void setImage(byte[] data) throws IOException {
+        serImage = new SerializableImage(ImageHelper.read(data));
+        clearCache();
+        setModified(true);
+    }
+
+    @Override
+    public ImageFormat getImageFormat() {
+        return ImageFormat.PNG;
+    }
+
+    @Override
+    public ImageFormat getOriginalImageFormat() {
+        return ImageFormat.PNG;
+    }
+
+    @Override
+    public InputStream getOriginalImageData() {
+        return null;
+    }
+
+    @Override
+    protected SerializableImage getImage() {
+        if (serImage == null) {
+            DefineExternalImage2 image = (DefineExternalImage2)swf.getImage(imageCharacterId | 0x8000);
+                
+            Path imagePath = Paths.get(image.getSwf().getFile()).getParent().resolve(Paths.get(image.fileName));
+            byte[] imageData;
+            try {
+                imageData = Files.readAllBytes(imagePath);
+            } catch (IOException e) {
+                return null;
+            }
+            int [] pixels = DDSReader.read(imageData, DDSReader.ARGB, 0);
+            BufferedImage bufImage = new BufferedImage(DDSReader.getWidth(imageData), DDSReader.getHeight(imageData), BufferedImage.TYPE_INT_ARGB);
+            bufImage.getRaster().setDataElements(0, 0, bufImage.getWidth(), bufImage.getHeight(), pixels);
+            Image scaled = bufImage.getScaledInstance(image.targetWidth, image.targetHeight, Image.SCALE_DEFAULT);
+            bufImage = new BufferedImage(x2 - x1, y2 - y1, BufferedImage.TYPE_INT_ARGB);
+            bufImage.getGraphics().drawImage(scaled, -x1, -y1, null);
+            serImage = new SerializableImage(bufImage);
+        }
+        return serImage;
+    }
+
+    @Override
+    public Dimension getImageDimension() {
+        return new Dimension(x2 - x1, y2 - y1);
     }
 }


### PR DESCRIPTION
Adds support for loading external DDS images in `DefineExternalImage2` and `DefineSubImage`. This builds on #101, which previously added support for `DefineExternalImage`.

There are still some issues, e.g. some character ids are shared across different tags (so cannot be used to uniquely identify a tag) and there are some graphical glitches but I do not understand the codebase well enough to do a major refactor and I feel it is in a good state to be merged.

Some examples from Star Wars: The Old Republic, which previously only showed up as red blobs:

![bwaui_characterdisplay.gfx](https://user-images.githubusercontent.com/26947989/158236744-02f6be5d-33c5-4616-bd06-1fa15ac1e721.png)

![bwaui_alderaanscorecard.gfx](https://user-images.githubusercontent.com/26947989/158236961-f91529a8-f859-428e-8c14-8aab1a08428b.png)

![bwaui_mission_reward.gfx](https://user-images.githubusercontent.com/26947989/158237500-616b0eb7-c159-4151-90f1-7c83ae0f8856.png)