### PR TITLE
Add Symbol-Class export support for commandline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Replace characters references
 
+### Fixed
+- [#1834] PlaceObject4 tags appear as Unresolved inside of DefineSprite
+
 ## [15.1.1] - 2022-07-03
 ### Added
 - Support for loading external images in DefineExternalImage2, DefineSubImage
@@ -2246,7 +2249,9 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Initial public release
 
-[Unreleased]: https://github.com/jindrapetrik/jpexs-decompiler/compare/version15.0.0...dev
+[Unreleased]: https://github.com/jindrapetrik/jpexs-decompiler/compare/version15.1.1...dev
+[15.1.1]: https://github.com/jindrapetrik/jpexs-decompiler/compare/version15.1.0...version15.1.1
+[15.1.0]: https://github.com/jindrapetrik/jpexs-decompiler/compare/version15.0.0...version15.1.0
 [15.0.0]: https://github.com/jindrapetrik/jpexs-decompiler/compare/version14.6.0...version15.0.0
 [14.6.0]: https://github.com/jindrapetrik/jpexs-decompiler/compare/version14.5.2...version14.6.0
 [14.5.2]: https://github.com/jindrapetrik/jpexs-decompiler/compare/version14.5.1...version14.5.2
@@ -2365,15 +2370,16 @@ All notable changes to this project will be documented in this file.
 [alpha 9]: https://github.com/jindrapetrik/jpexs-decompiler/compare/alpha8...alpha9
 [alpha 8]: https://github.com/jindrapetrik/jpexs-decompiler/compare/alpha7...alpha8
 [alpha 7]: https://github.com/jindrapetrik/jpexs-decompiler/releases/tag/alpha7
+[#1834]: https://www.free-decompiler.com/flash/issues/1834
 [#270]: https://www.free-decompiler.com/flash/issues/270
 [#1718]: https://www.free-decompiler.com/flash/issues/1718
+[#1801]: https://www.free-decompiler.com/flash/issues/1801
 [#1761]: https://www.free-decompiler.com/flash/issues/1761
 [#1762]: https://www.free-decompiler.com/flash/issues/1762
 [#1763]: https://www.free-decompiler.com/flash/issues/1763
 [#1766]: https://www.free-decompiler.com/flash/issues/1766
 [#1773]: https://www.free-decompiler.com/flash/issues/1773
 [#1769]: https://www.free-decompiler.com/flash/issues/1769
-[#1801]: https://www.free-decompiler.com/flash/issues/1801
 [#1750]: https://www.free-decompiler.com/flash/issues/1750
 [#1485]: https://www.free-decompiler.com/flash/issues/1485
 [#1681]: https://www.free-decompiler.com/flash/issues/1681

--- a/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/SWFInputStream.java
+++ b/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/SWFInputStream.java
@@ -1228,9 +1228,10 @@ public class SWFInputStream implements AutoCloseable {
                     case ShowFrameTag.ID:
                     case PlaceObjectTag.ID:
                     case PlaceObject2Tag.ID:
+                    case PlaceObject3Tag.ID:
+                    case PlaceObject4Tag.ID:
                     case RemoveObjectTag.ID:
                     case RemoveObject2Tag.ID:
-                    case PlaceObject3Tag.ID: // ?
                     case StartSoundTag.ID:
                     case FrameLabelTag.ID:
                     case SoundStreamHeadTag.ID:

--- a/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/exporters/settings/SymbolClassExportSettings.java
+++ b/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/exporters/settings/SymbolClassExportSettings.java
@@ -1,0 +1,34 @@
+/*
+ *  Copyright (C) 2010-2022 JPEXS, All rights reserved.
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
+package com.jpexs.decompiler.flash.exporters.settings;
+
+import com.jpexs.decompiler.flash.exporters.modes.SymbolClassExportMode;
+
+/**
+ *
+ * @author Dofera
+ */
+public class SymbolClassExportSettings {
+
+    public static final String EXPORT_FOLDER_NAME = "symbolClass";
+
+    public SymbolClassExportMode mode;
+
+    public SymbolClassExportSettings(SymbolClassExportMode mode) {
+        this.mode = mode;
+    }
+}

--- a/src/com/jpexs/decompiler/flash/console/CommandLineArgumentParser.java
+++ b/src/com/jpexs/decompiler/flash/console/CommandLineArgumentParser.java
@@ -60,6 +60,7 @@ import com.jpexs.decompiler.flash.exporters.MorphShapeExporter;
 import com.jpexs.decompiler.flash.exporters.MovieExporter;
 import com.jpexs.decompiler.flash.exporters.ShapeExporter;
 import com.jpexs.decompiler.flash.exporters.SoundExporter;
+import com.jpexs.decompiler.flash.exporters.SymbolClassExporter;
 import com.jpexs.decompiler.flash.exporters.TextExporter;
 import com.jpexs.decompiler.flash.exporters.amf.amf3.Amf3Exporter;
 import com.jpexs.decompiler.flash.exporters.commonshape.Matrix;
@@ -74,6 +75,7 @@ import com.jpexs.decompiler.flash.exporters.modes.ScriptExportMode;
 import com.jpexs.decompiler.flash.exporters.modes.ShapeExportMode;
 import com.jpexs.decompiler.flash.exporters.modes.SoundExportMode;
 import com.jpexs.decompiler.flash.exporters.modes.SpriteExportMode;
+import com.jpexs.decompiler.flash.exporters.modes.SymbolClassExportMode;
 import com.jpexs.decompiler.flash.exporters.modes.TextExportMode;
 import com.jpexs.decompiler.flash.exporters.script.LinkReportExporter;
 import com.jpexs.decompiler.flash.exporters.settings.BinaryDataExportSettings;
@@ -87,6 +89,7 @@ import com.jpexs.decompiler.flash.exporters.settings.ScriptExportSettings;
 import com.jpexs.decompiler.flash.exporters.settings.ShapeExportSettings;
 import com.jpexs.decompiler.flash.exporters.settings.SoundExportSettings;
 import com.jpexs.decompiler.flash.exporters.settings.SpriteExportSettings;
+import com.jpexs.decompiler.flash.exporters.settings.SymbolClassExportSettings;
 import com.jpexs.decompiler.flash.exporters.settings.TextExportSettings;
 import com.jpexs.decompiler.flash.exporters.swf.SwfToSwcExporter;
 import com.jpexs.decompiler.flash.exporters.swf.SwfXmlExporter;
@@ -331,6 +334,7 @@ public class CommandLineArgumentParser {
             out.println("        button - Buttons (Default format: PNG)");
             out.println("        sound - Sounds (Default format: MP3/WAV/FLV only sound)");
             out.println("        binaryData - Binary data (Default format:  Raw data)");
+            out.println("        symbolClass - Symbol-Class mapping (Default format: CSV)");
             out.println("        text - Texts (Default format: Plain text)");
             out.println("        all - Every resource (but not FLA and XFL)");
             out.println("        fla - Everything to FLA compressed format");
@@ -2097,6 +2101,7 @@ public class CommandLineArgumentParser {
             "button",
             "sound",
             "binarydata",
+            "symbolclass",
             "text",
             "all",
             "fla",
@@ -2274,6 +2279,11 @@ public class CommandLineArgumentParser {
                 if (exportAll || exportFormats.contains("binarydata")) {
                     System.out.println("Exporting binaryData...");
                     new BinaryDataExporter().exportBinaryData(handler, outDir + (multipleExportTypes ? File.separator + BinaryDataExportSettings.EXPORT_FOLDER_NAME : ""), new ReadOnlyTagList(extags), new BinaryDataExportSettings(enumFromStr(formats.get("binarydata"), BinaryDataExportMode.class)), evl);
+                }
+
+                if (exportAll || exportFormats.contains("symbolclass")) {
+                    System.out.println("Exporting symbolClass...");
+                    new SymbolClassExporter().exportNames(handler, outDir + (multipleExportTypes ? File.separator + SymbolClassExportSettings.EXPORT_FOLDER_NAME : ""), new ReadOnlyTagList(extags), new SymbolClassExportSettings(enumFromStr(formats.get("symbolclass"), SymbolClassExportMode.class)), evl);
                 }
 
                 if (exportAll || exportFormats.contains("text")) {

--- a/src/com/jpexs/decompiler/flash/gui/MainPanel.java
+++ b/src/com/jpexs/decompiler/flash/gui/MainPanel.java
@@ -73,6 +73,7 @@ import com.jpexs.decompiler.flash.exporters.settings.ScriptExportSettings;
 import com.jpexs.decompiler.flash.exporters.settings.ShapeExportSettings;
 import com.jpexs.decompiler.flash.exporters.settings.SoundExportSettings;
 import com.jpexs.decompiler.flash.exporters.settings.SpriteExportSettings;
+import com.jpexs.decompiler.flash.exporters.settings.SymbolClassExportSettings;
 import com.jpexs.decompiler.flash.exporters.settings.TextExportSettings;
 import com.jpexs.decompiler.flash.exporters.swf.SwfJavaExporter;
 import com.jpexs.decompiler.flash.exporters.swf.SwfXmlExporter;
@@ -1383,7 +1384,8 @@ public final class MainPanel extends JPanel implements TreeSelectionListener, Se
             }
 
             if (export.isOptionEnabled(SymbolClassExportMode.class)) {
-                ret.addAll(new SymbolClassExporter().exportNames(selFile2, new ReadOnlyTagList(symbolNames), evl));
+                ret.addAll(new SymbolClassExporter().exportNames(handler, selFile2 + File.separator + SymbolClassExportSettings.EXPORT_FOLDER_NAME, new ReadOnlyTagList(symbolNames),
+                        new SymbolClassExportSettings(export.getValue(SymbolClassExportMode.class)), evl));
             }
 
             FrameExporter frameExporter = new FrameExporter();
@@ -1495,7 +1497,8 @@ public final class MainPanel extends JPanel implements TreeSelectionListener, Se
         }
 
         if (export.isOptionEnabled(SymbolClassExportMode.class)) {
-            new SymbolClassExporter().exportNames(selFile, swf.getTags(), evl);
+            new SymbolClassExporter().exportNames(handler, Path.combine(selFile, SymbolClassExportSettings.EXPORT_FOLDER_NAME), swf.getTags(),
+                    new SymbolClassExportSettings(export.getValue(SymbolClassExportMode.class)), evl);
         }
 
         FrameExporter frameExporter = new FrameExporter();
@@ -1603,7 +1606,8 @@ public final class MainPanel extends JPanel implements TreeSelectionListener, Se
 
         if (export.isOptionEnabled(SymbolClassExportMode.class)) {
             for (SymbolClassExportMode exportMode : SymbolClassExportMode.values()) {
-                new SymbolClassExporter().exportNames(selFile, swf.getTags(), evl);
+                new SymbolClassExporter().exportNames(handler, Path.combine(selFile, SymbolClassExportSettings.EXPORT_FOLDER_NAME, exportMode.name()), swf.getTags(),
+                        new SymbolClassExportSettings(exportMode), evl);
             }
         }
 


### PR DESCRIPTION
Can now export Symbol-Class mapping directly from CLI.

Example: `java -jar ffdec.jar -export symbolClass . myfile.swf`