### PR TITLE
Clone tags and frames

### DIFF
--- a/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/SWF.java
+++ b/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/SWF.java
@@ -3190,13 +3190,19 @@ public final class SWF implements SWFContainerItem, Timelined {
             updateCharacters();
         }
     }
+    
+    public int indexOfTag(Tag tag) {
+        return tags.indexOf(tag);
+    }
 
     /**
-     * Adds a tag to the SWF If targetTreeItem is: - Frame: adds the tag to the
+     * Adds a tag to the SWF If targetTreeItem is: 
+     * - Frame: adds the tag to the
      * Frame. Frame can be a frame of the main timeline or a DefineSprite frame
-     * - DefineSprite: adds the tag to the end of the DefineSprite's tag list -
-     * Any other tag in the SWF: adds the new tag exactly before the specified
-     * tag - Other: adds the tag to the end of the SWF's tag list
+     * - DefineSprite: adds the tag to the end of the DefineSprite's tag list
+     * - Any other tag in the SWF: adds the new tag exactly before the specified
+     * tag
+     * - Other: adds the tag to the end of the SWF's tag list
      *
      * @param tag
      * @param targetTreeItem

--- a/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/tags/DefineSpriteTag.java
+++ b/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/tags/DefineSpriteTag.java
@@ -324,6 +324,11 @@ public class DefineSpriteTag extends DrawableTag implements Timelined {
     }
 
     @Override
+    public int indexOfTag(Tag tag) {
+        return subTags.indexOf(tag);
+    }
+
+    @Override
     public void createOriginalData() {
         super.createOriginalData();
         for (Tag subTag : getTags()) {

--- a/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/tags/base/ButtonTag.java
+++ b/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/tags/base/ButtonTag.java
@@ -172,6 +172,11 @@ public abstract class ButtonTag extends DrawableTag implements Timelined {
     @Override
     public void addTag(int index, Tag tag) {
     }
+    
+    @Override
+    public int indexOfTag(Tag tag) {
+        return -1;
+    }
 
     @Override
     public void replaceTag(int index, Tag newTag) {

--- a/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/timeline/Timelined.java
+++ b/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/timeline/Timelined.java
@@ -12,7 +12,8 @@
  * Lesser General Public License for more details.
  * 
  * You should have received a copy of the GNU Lesser General Public
- * License along with this library. */
+ * License along with this library.
+ */
 package com.jpexs.decompiler.flash.timeline;
 
 import com.jpexs.decompiler.flash.ReadOnlyTagList;
@@ -42,4 +43,6 @@ public interface Timelined extends BoundedTag {
     public void addTag(int index, Tag tag);
 
     public void replaceTag(int index, Tag newTag);
+    
+    public int indexOfTag(Tag tag);
 }

--- a/src/com/jpexs/decompiler/flash/gui/MainPanel.java
+++ b/src/com/jpexs/decompiler/flash/gui/MainPanel.java
@@ -4050,6 +4050,11 @@ public final class MainPanel extends JPanel implements TreeSelectionListener, Se
             }
 
             @Override
+            public int indexOfTag(Tag tag) {
+                return -1;            
+            }
+
+            @Override
             public RECT getRectWithStrokes() {
                 return getRect();
             }

--- a/src/com/jpexs/decompiler/flash/gui/locales/MainFrame.properties
+++ b/src/com/jpexs/decompiler/flash/gui/locales/MainFrame.properties
@@ -858,3 +858,5 @@ work.injecting_debuginfo = Injecting debug info
 work.generating_swd = Generating SWD file
 
 button.replaceRefs = Replace references with other character ID
+
+contextmenu.cloneTag = Clone tag

--- a/src/com/jpexs/decompiler/flash/gui/tagtree/TagTreeModel.java
+++ b/src/com/jpexs/decompiler/flash/gui/tagtree/TagTreeModel.java
@@ -264,7 +264,7 @@ public class TagTreeModel implements TreeModel {
             TreeItem sound = sounds.get(i);
             if (sound instanceof SoundStreamHeadTypeTag) {
                 List<SoundStreamBlockTag> blocks = ((SoundStreamHeadTypeTag) sound).getBlocks();
-                if (blocks.isEmpty()) {
+                if (blocks == null || blocks.isEmpty()) {
                     sounds.remove(i);
                 }
             }


### PR DESCRIPTION
Add a way to clone tags and frames. Both are cloned and added after the original (frames clone their inner tags instead of just the ShowFrameTag)

For now only tags/frame with the same parent can be cloned to prevent the confusing case of having a tag and its inner tag trying to be cloned at the same time