### PR TITLE
How do I export from multiple files?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
 ## [16.1.0] - 2022-11-06
 ### Added
 - [#1459], [#1832], [#1849] AS1/2 direct editation - Error dialog when saved value (UI16, SI16, ...) exceeds its limit and this code cannot be saved.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+### Added
+- [#1414] Cancelling in-progress exportation
+
+### Fixed
+- FLA export printing xxx string on exporting character with id 320
 
 ## [16.1.0] - 2022-11-06
 ### Added
@@ -2376,7 +2381,8 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Initial public release
 
-[Unreleased]: https://github.com/jindrapetrik/jpexs-decompiler/compare/version16.0.4...dev
+[Unreleased]: https://github.com/jindrapetrik/jpexs-decompiler/compare/version16.1.0...dev
+[16.1.0]: https://github.com/jindrapetrik/jpexs-decompiler/compare/version16.0.4...version16.1.0
 [16.0.4]: https://github.com/jindrapetrik/jpexs-decompiler/compare/version16.0.3...version16.0.4
 [16.0.3]: https://github.com/jindrapetrik/jpexs-decompiler/compare/version16.0.2...version16.0.3
 [16.0.2]: https://github.com/jindrapetrik/jpexs-decompiler/compare/version16.0.1...version16.0.2
@@ -2502,6 +2508,7 @@ All notable changes to this project will be documented in this file.
 [alpha 9]: https://github.com/jindrapetrik/jpexs-decompiler/compare/alpha8...alpha9
 [alpha 8]: https://github.com/jindrapetrik/jpexs-decompiler/compare/alpha7...alpha8
 [alpha 7]: https://github.com/jindrapetrik/jpexs-decompiler/releases/tag/alpha7
+[#1414]: https://www.free-decompiler.com/flash/issues/1414
 [#1459]: https://www.free-decompiler.com/flash/issues/1459
 [#1832]: https://www.free-decompiler.com/flash/issues/1832
 [#1849]: https://www.free-decompiler.com/flash/issues/1849

--- a/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/exporters/BinaryDataExporter.java
+++ b/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/exporters/BinaryDataExporter.java
@@ -41,6 +41,10 @@ public class BinaryDataExporter {
 
     public List<File> exportBinaryData(AbortRetryIgnoreHandler handler, String outdir, ReadOnlyTagList tags, BinaryDataExportSettings settings, EventListener evl) throws IOException, InterruptedException {
         List<File> ret = new ArrayList<>();
+        if (Thread.currentThread().isInterrupted()) {
+            return ret;
+        }
+        
         if (tags.isEmpty()) {
             return ret;
         }
@@ -77,6 +81,10 @@ public class BinaryDataExporter {
 
                 ret.add(file);
 
+                if (Thread.currentThread().isInterrupted()) {
+                    break;
+                }
+        
                 if (evl != null) {
                     evl.handleExportedEvent("binarydata", currentIndex, count, t.getName());
                 }

--- a/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/exporters/FontExporter.java
+++ b/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/exporters/FontExporter.java
@@ -61,6 +61,10 @@ public class FontExporter {
 
     public List<File> exportFonts(AbortRetryIgnoreHandler handler, String outdir, ReadOnlyTagList tags, final FontExportSettings settings, EventListener evl) throws IOException, InterruptedException {
         List<File> ret = new ArrayList<>();
+        if (Thread.currentThread().isInterrupted()) {
+            return ret;
+        }
+        
         if (tags.isEmpty()) {
             return ret;
         }
@@ -97,6 +101,10 @@ public class FontExporter {
                 }, handler).run();
 
                 ret.add(file);
+
+                if (Thread.currentThread().isInterrupted()) {
+                    break;
+                }
 
                 if (evl != null) {
                     evl.handleExportedEvent("font", currentIndex, count, t.getName());

--- a/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/exporters/ImageExporter.java
+++ b/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/exporters/ImageExporter.java
@@ -45,6 +45,10 @@ public class ImageExporter {
 
     public List<File> exportImages(AbortRetryIgnoreHandler handler, String outdir, ReadOnlyTagList tags, ImageExportSettings settings, EventListener evl) throws IOException, InterruptedException {
         List<File> ret = new ArrayList<>();
+        if (Thread.currentThread().isInterrupted()) {
+            return ret;
+        }
+        
         if (tags.isEmpty()) {
             return ret;
         }
@@ -102,6 +106,10 @@ public class ImageExporter {
                         }
                     }, handler).run();
                     ret.add(file);
+                }
+                
+                if (Thread.currentThread().isInterrupted()) {
+                    break;
                 }
 
                 if (evl != null) {

--- a/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/exporters/MorphShapeExporter.java
+++ b/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/exporters/MorphShapeExporter.java
@@ -57,6 +57,10 @@ public class MorphShapeExporter {
     //TODO: implement morphshape export. How to handle 65536 frames?
     public List<File> exportMorphShapes(AbortRetryIgnoreHandler handler, final String outdir, ReadOnlyTagList tags, final MorphShapeExportSettings settings, EventListener evl) throws IOException, InterruptedException {
         List<File> ret = new ArrayList<>();
+        if (Thread.currentThread().isInterrupted()) {
+            return ret;
+        }
+        
         if (tags.isEmpty()) {
             return ret;
         }
@@ -132,6 +136,9 @@ public class MorphShapeExporter {
                 }, handler).run();
                 ret.add(file);
 
+                if (Thread.currentThread().isInterrupted()) {
+                    break;
+                }
                 if (evl != null) {
                     evl.handleExportedEvent("morphshape", currentIndex, count, t.getName());
                 }

--- a/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/exporters/MovieExporter.java
+++ b/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/exporters/MovieExporter.java
@@ -52,6 +52,9 @@ public class MovieExporter {
 
     public List<File> exportMovies(AbortRetryIgnoreHandler handler, String outdir, ReadOnlyTagList tags, final MovieExportSettings settings, EventListener evl) throws IOException, InterruptedException {
         List<File> ret = new ArrayList<>();
+        if (Thread.currentThread().isInterrupted()) {
+            return ret;
+        }
         if (tags.isEmpty()) {
             return ret;
         }
@@ -85,6 +88,9 @@ public class MovieExporter {
                     }
                 }, handler).run();
 
+                if (Thread.currentThread().isInterrupted()) {
+                    break;
+                }
                 if (evl != null) {
                     evl.handleExportedEvent("movie", currentIndex, count, t.getName());
                 }

--- a/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/exporters/ShapeExporter.java
+++ b/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/exporters/ShapeExporter.java
@@ -65,6 +65,10 @@ public class ShapeExporter {
 
     public List<File> exportShapes(AbortRetryIgnoreHandler handler, final String outdir, final SWF swf, ReadOnlyTagList tags, final ShapeExportSettings settings, EventListener evl, double unzoom) throws IOException, InterruptedException {
         List<File> ret = new ArrayList<>();
+        if (Thread.currentThread().isInterrupted()) {
+            return ret;
+        }
+        
         if (tags.isEmpty()) {
             return ret;
         }
@@ -159,6 +163,9 @@ public class ShapeExporter {
                 }, handler).run();
                 ret.add(file);
 
+                if (Thread.currentThread().isInterrupted()) {
+                    break;
+                }
                 if (evl != null) {
                     evl.handleExportedEvent("shape", currentIndex, count, t.getName());
                 }

--- a/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/exporters/SoundExporter.java
+++ b/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/exporters/SoundExporter.java
@@ -53,6 +53,10 @@ public class SoundExporter {
 
     public List<File> exportSounds(AbortRetryIgnoreHandler handler, String outdir, ReadOnlyTagList tags, final SoundExportSettings settings, EventListener evl) throws IOException, InterruptedException {
         List<File> ret = new ArrayList<>();
+        if (Thread.currentThread().isInterrupted()) {
+            return ret;
+        }
+        
         if (tags.isEmpty()) {
             return ret;
         }
@@ -106,6 +110,10 @@ public class SoundExporter {
                 }, handler).run();
 
                 ret.add(file);
+
+                if (Thread.currentThread().isInterrupted()) {
+                    break;
+                }
 
                 if (evl != null) {
                     evl.handleExportedEvent("sound", currentIndex, count, t.getName());

--- a/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/exporters/SymbolClassExporter.java
+++ b/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/exporters/SymbolClassExporter.java
@@ -45,6 +45,10 @@ public class SymbolClassExporter {
 
     public List<File> exportNames(AbortRetryIgnoreHandler handler, final String outdir, ReadOnlyTagList tags, SymbolClassExportSettings settings, EventListener evl) throws IOException, InterruptedException {
         List<File> ret = new ArrayList<>();
+        if (Thread.currentThread().isInterrupted()) {
+            return ret;
+        }
+        
         int count = 0;
         for (Tag t : tags) {
             if (t instanceof ExportAssetsTag || t instanceof SymbolClassTag) {
@@ -73,6 +77,9 @@ public class SymbolClassExporter {
                         for (int i = 0; i < sct.tags.size(); i++) {
                             writer.append(sct.tags.get(i) + ";" + sct.names.get(i) + Helper.newLine);
                         }
+                    }
+                    if (Thread.currentThread().isInterrupted()) {
+                        break;
                     }
                 }
             }

--- a/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/exporters/TextExporter.java
+++ b/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/exporters/TextExporter.java
@@ -51,6 +51,10 @@ public class TextExporter {
 
     public List<File> exportTexts(AbortRetryIgnoreHandler handler, String outdir, ReadOnlyTagList tags, final TextExportSettings settings, EventListener evl) throws IOException, InterruptedException {
         List<File> ret = new ArrayList<>();
+        if (Thread.currentThread().isInterrupted()) {
+            return ret;
+        }
+        
         if (tags.isEmpty()) {
             return ret;
         }
@@ -125,6 +129,9 @@ public class TextExporter {
                             fos.write(Utf8Helper.getBytes(Helper.newLine + Configuration.textExportSingleFileSeparator.get() + Helper.newLine));
                         }, handler).run();
                     }
+                    if (Thread.currentThread().isInterrupted()) {
+                        break;
+                    }
                 }
             }
             ret.add(file);
@@ -151,6 +158,9 @@ public class TextExporter {
                     }, handler).run();
                     ret.add(file);
 
+                    if (Thread.currentThread().isInterrupted()) {
+                        break;
+                    }
                     if (evl != null) {
                         evl.handleExportedEvent("text", currentIndex, count, t.getName());
                     }

--- a/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/xfl/XFLConverter.java
+++ b/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/xfl/XFLConverter.java
@@ -2727,11 +2727,7 @@ public class XFLConverter {
         }
         if (!script.isEmpty()) {
             script = "#initclip\r\n" + script + "#endinitclip\r\n";
-        }
-        
-        if (spriteId == 320) {
-            System.err.println("xxx");
-        }
+        }        
 
         Map<Integer, String> frameToScriptMap = new HashMap<>();
 

--- a/src/com/jpexs/decompiler/flash/gui/Main.java
+++ b/src/com/jpexs/decompiler/flash/gui/Main.java
@@ -777,6 +777,14 @@ public class Main {
     public static void startWork(String name, CancellableWorker worker) {
         startWork(name, -1, worker);
     }
+    
+    public static void continueWork(String name) {
+        continueWork(name, -1);
+    }
+    
+    public static void continueWork(String name, final int percent) {
+        startWork(name, percent, mainFrame.getPanel().getCurrentWorker());
+    }
 
     public static void startWork(final String name, final int percent, final CancellableWorker worker) {
         working = true;
@@ -1075,7 +1083,7 @@ public class Main {
                         text += " " + type;
                     }
 
-                    startWork(text + " " + index + "/" + count + " " + data, null);
+                    continueWork(text + " " + index + "/" + count + " " + data);
                 }
 
                 @Override
@@ -1085,7 +1093,7 @@ public class Main {
                         text += " " + type;
                     }
 
-                    startWork(text + " " + index + "/" + count + " " + data, null);
+                    continueWork(text + " " + index + "/" + count + " " + data);
                 }
 
                 @Override
@@ -1094,16 +1102,16 @@ public class Main {
                         throw new Error("Event is not supported by this handler.");
                     }
                     if (event.equals("getVariables")) {
-                        startWork(AppStrings.translate("work.gettingvariables") + "..." + (String) data, null);
+                        continueWork(AppStrings.translate("work.gettingvariables") + "..." + (String) data);
                     }
                     if (event.equals("deobfuscate")) {
-                        startWork(AppStrings.translate("work.deobfuscating") + "..." + (String) data, null);
+                        continueWork(AppStrings.translate("work.deobfuscating") + "..." + (String) data);
                     }
                     if (event.equals("deobfuscate_pcode")) {
                         startWork(AppStrings.translate("work.deobfuscating_pcode") + "..." + (String) data, deobfuscatePCodeWorker);
                     }
                     if (event.equals("rename")) {
-                        startWork(AppStrings.translate("work.renaming") + "..." + (String) data, null);
+                        continueWork(AppStrings.translate("work.renaming") + "..." + (String) data);
                     }
                     if (event.equals("importing_as")) {
                         startWork(AppStrings.translate("work.importing_as") + "..." + (String) data, importWorker);

--- a/src/com/jpexs/decompiler/flash/gui/MainFrameStatusPanel.java
+++ b/src/com/jpexs/decompiler/flash/gui/MainFrameStatusPanel.java
@@ -109,6 +109,10 @@ public class MainFrameStatusPanel extends JPanel {
         statusLabel.setText(s);
     }
 
+    public CancellableWorker getCurrentWorker() {
+        return currentWorker;
+    }   
+    
     public void setWorkStatus(String s, CancellableWorker worker) {
         if (s.isEmpty()) {
             loadingPanel.setVisible(false);

--- a/src/com/jpexs/decompiler/flash/gui/MainPanel.java
+++ b/src/com/jpexs/decompiler/flash/gui/MainPanel.java
@@ -529,6 +529,10 @@ public final class MainPanel extends JPanel implements TreeSelectionListener, Se
         statusPanel.setWorkStatus(s, worker);
         mainMenu.updateComponents();
     }
+    
+    public CancellableWorker getCurrentWorker() {
+        return statusPanel.getCurrentWorker();
+    }
 
     private JPanel createWelcomePanel() {
         JPanel welcomePanel = new JPanel();


### PR DESCRIPTION
I'm kinda doing a personal mega-project so I want to export all "movies" from multiple old swf files at once (thank for allowing us to export only certain types). But when I load multiple files on JPEXS and select them all, the program only exports from the first file, ignoring the rest I selected. Since I want to export from dozens upon dozens of swf files (im talking about over 20 "projects", with over 200 swf files in total) so it's not very practical to manually export each swf separately.

I only found 2 other people with this issue. The first person said they fixed it by using a nightly version, the second person said they read about the 1st person but it didn't work for them. I tried on my v.14.0.0 (the one I've been using for a while). Then got v.16.1.0 and tried on v.16.1.0 nightly build 2145. I've had this issue with all of them.