### PR TITLE
Do not expand tag tree after a SWF is added or closed

### DIFF
--- a/src/com/jpexs/decompiler/flash/gui/MainPanel.java
+++ b/src/com/jpexs/decompiler/flash/gui/MainPanel.java
@@ -845,7 +845,6 @@ public final class MainPanel extends JPanel implements TreeSelectionListener, Se
                 }
                 ttm.updateSwfs(e);
                 tagTree.expandRoot();
-                tagTree.expandFirstLevelNodes();
             }
             ttm = tagListTree.getModel();
             if (ttm != null) {


### PR DESCRIPTION
This PR will remove the behaviour, that **ALL** SWFs are opened after a SWF is added or removed. 
This behaviour is unfortunately annoying when working with a lot of SWFs in the `tagTree` as every add or remove modification will expand everything again, even though you closed all of them before.

If this is the desired behaviour, we can also add a `Configuration` flag for that, so users can decide whether they want this behaviour or not.
Also if desired, I can adjust this behaviour for the `tagListTree` and the `dumpTree` as well, as those two are also affected by the above described behaviour.