### PR TITLE
Unable to export .fla file from .swf file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
 ## [18.3.2] - 2023-01-10
 ### Removed
 - [#1935], [#1913] Retaining shape exact position(bounds) in SVG export/import
@@ -2715,6 +2717,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Initial public release
 
+[Unreleased]: https://github.com/jindrapetrik/jpexs-decompiler/compare/version18.3.2...dev
 [18.3.2]: https://github.com/jindrapetrik/jpexs-decompiler/compare/version18.3.1...version18.3.2
 [18.3.1]: https://github.com/jindrapetrik/jpexs-decompiler/compare/version18.3.0...version18.3.1
 [18.3.0]: https://github.com/jindrapetrik/jpexs-decompiler/compare/version18.2.1...version18.3.0


### PR DESCRIPTION
I have tried with various old flash games, and every time FFDEC gets stuck, says it is exporting and loading for over an hour, and anything that is exported successfully is incomplete and/or corrupted. These files are 8,000 Kb at most, so size is not an issue. I have tried this with the latest release, as well as older releases before this one came out. Unsure of what to do. I was not sure where to bring up this issue, and the pull request was more confusing than usual because of multiple branches, so I apologize if this is an inappropriate place to ask.