### PR TITLE
Collect PlaceObjectTypeTag/RemoveObjectTag by depth as Sprites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
 ## [18.5.0] - 2023-06-25
 ### Added
 - [#1998] Setting for maximum number of items in the cache - allows less memory consumption (Defaults to 500 per cache)
@@ -2888,6 +2890,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Initial public release
 
+[Unreleased]: https://github.com/jindrapetrik/jpexs-decompiler/compare/version18.5.0...dev
 [18.5.0]: https://github.com/jindrapetrik/jpexs-decompiler/compare/version18.4.1...version18.5.0
 [18.4.1]: https://github.com/jindrapetrik/jpexs-decompiler/compare/version18.4.0...version18.4.1
 [18.4.0]: https://github.com/jindrapetrik/jpexs-decompiler/compare/version18.3.6...version18.4.0

--- a/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/tags/DefineSpriteTag.java
+++ b/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/tags/DefineSpriteTag.java
@@ -26,6 +26,7 @@ import com.jpexs.decompiler.flash.exporters.commonshape.SVGExporter;
 import com.jpexs.decompiler.flash.tags.base.BoundedTag;
 import com.jpexs.decompiler.flash.tags.base.CharacterIdTag;
 import com.jpexs.decompiler.flash.tags.base.CharacterTag;
+import com.jpexs.decompiler.flash.tags.base.DepthTag;
 import com.jpexs.decompiler.flash.tags.base.DrawableTag;
 import com.jpexs.decompiler.flash.tags.base.FontTag;
 import com.jpexs.decompiler.flash.tags.base.PlaceObjectTypeTag;
@@ -54,7 +55,9 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.TreeSet;
 
 /**
  * Defines a sprite character
@@ -508,5 +511,29 @@ public class DefineSpriteTag extends DrawableTag implements Timelined {
     @Override
     public void setFrameCount(int frameCount) {
         this.frameCount = frameCount;
-    }  
+    }
+    
+    public void compactDepths() {
+        Set<Integer> depths = new TreeSet<>();
+                        
+        for(Tag t : subTags) {
+            if(t instanceof DepthTag) {
+                depths.add(((DepthTag)t).getDepth());
+            }
+        }
+
+        Map<Integer, Integer> depthMap = new HashMap<>();
+        int j = 0;
+        for(int d : depths) {
+            depthMap.put(d, j);
+            j++;
+        }
+
+        for(Tag t : subTags) {
+            if(t instanceof DepthTag) {
+                DepthTag dt = (DepthTag)t;
+                dt.setDepth(depthMap.get(dt.getDepth()));
+            }
+        }
+    }
 }

--- a/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/tags/PlaceObject2Tag.java
+++ b/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/tags/PlaceObject2Tag.java
@@ -332,6 +332,11 @@ public class PlaceObject2Tag extends PlaceObjectTypeTag implements ASMSourceCont
     }
 
     @Override
+    public void setDepth(int depth) {
+        this.depth = depth;
+    }
+
+    @Override
     public MATRIX getMatrix() {
         if (placeFlagHasMatrix) {
             return matrix;

--- a/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/tags/PlaceObject2Tag.java
+++ b/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/tags/PlaceObject2Tag.java
@@ -474,6 +474,11 @@ public class PlaceObject2Tag extends PlaceObjectTypeTag implements ASMSourceCont
     }
 
     @Override
+    public void setPlaceFlagMove(boolean placeFlagMove) {
+        this.placeFlagMove = placeFlagMove;
+    }
+
+    @Override
     public boolean hasImage() {
         return false;
     }

--- a/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/tags/PlaceObject3Tag.java
+++ b/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/tags/PlaceObject3Tag.java
@@ -519,6 +519,11 @@ public class PlaceObject3Tag extends PlaceObjectTypeTag implements ASMSourceCont
     }
 
     @Override
+    public void setDepth(int depth) {
+        this.depth = depth;
+    }
+
+    @Override
     public MATRIX getMatrix() {
         if (placeFlagHasMatrix) {
             return matrix;

--- a/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/tags/PlaceObject3Tag.java
+++ b/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/tags/PlaceObject3Tag.java
@@ -677,6 +677,11 @@ public class PlaceObject3Tag extends PlaceObjectTypeTag implements ASMSourceCont
     }
 
     @Override
+    public void setPlaceFlagMove(boolean placeFlagMove) {
+        this.placeFlagMove = placeFlagMove;
+    }
+
+    @Override
     public boolean hasImage() {
         return placeFlagHasImage;
     }

--- a/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/tags/PlaceObject4Tag.java
+++ b/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/tags/PlaceObject4Tag.java
@@ -540,6 +540,11 @@ public class PlaceObject4Tag extends PlaceObjectTypeTag implements ASMSourceCont
     }
 
     @Override
+    public void setDepth(int depth) {
+        this.depth = depth;
+    }
+
+    @Override
     public MATRIX getMatrix() {
         if (placeFlagHasMatrix) {
             return matrix;

--- a/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/tags/PlaceObject4Tag.java
+++ b/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/tags/PlaceObject4Tag.java
@@ -698,6 +698,11 @@ public class PlaceObject4Tag extends PlaceObjectTypeTag implements ASMSourceCont
     }
 
     @Override
+    public void setPlaceFlagMove(boolean placeFlagMove) {
+        this.placeFlagMove = placeFlagMove;
+    }
+
+    @Override
     public boolean hasImage() {
         return placeFlagHasImage;
     }

--- a/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/tags/PlaceObjectTag.java
+++ b/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/tags/PlaceObjectTag.java
@@ -174,6 +174,11 @@ public class PlaceObjectTag extends PlaceObjectTypeTag {
     }
 
     @Override
+    public void setDepth(int depth) {
+        this.depth = depth;
+    }
+
+    @Override
     public MATRIX getMatrix() {
         return matrix;
     }

--- a/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/tags/PlaceObjectTag.java
+++ b/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/tags/PlaceObjectTag.java
@@ -288,6 +288,11 @@ public class PlaceObjectTag extends PlaceObjectTypeTag {
     }
 
     @Override
+    public void setPlaceFlagMove(boolean placeFlagMove) {
+        
+    }
+
+    @Override
     public boolean hasImage() {
         return false;
     }

--- a/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/tags/RemoveObject2Tag.java
+++ b/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/tags/RemoveObject2Tag.java
@@ -81,4 +81,9 @@ public class RemoveObject2Tag extends RemoveTag {
     public int getDepth() {
         return depth;
     }
+
+    @Override
+    public void setDepth(int depth) {
+        this.depth = depth;
+    }
 }

--- a/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/tags/RemoveObjectTag.java
+++ b/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/tags/RemoveObjectTag.java
@@ -98,6 +98,11 @@ public class RemoveObjectTag extends RemoveTag implements CharacterIdTag {
     }
 
     @Override
+    public void setDepth(int depth) {
+        this.depth = depth;
+    }
+
+    @Override
     public int getCharacterId() {
         return characterId;
     }

--- a/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/tags/base/DepthTag.java
+++ b/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/tags/base/DepthTag.java
@@ -1,0 +1,27 @@
+/*
+ *  Copyright (C) 2010-2023 JPEXS, All rights reserved.
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
+package com.jpexs.decompiler.flash.tags.base;
+
+/**
+ *
+ * @author JPEXS
+ */
+public interface DepthTag {
+    public int getDepth();
+    
+    public void setDepth(int depth);
+}

--- a/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/tags/base/PlaceObjectTypeTag.java
+++ b/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/tags/base/PlaceObjectTypeTag.java
@@ -33,15 +33,13 @@ import java.util.List;
  *
  * @author JPEXS
  */
-public abstract class PlaceObjectTypeTag extends Tag implements CharacterIdTag {
+public abstract class PlaceObjectTypeTag extends Tag implements CharacterIdTag, DepthTag {
 
     public PlaceObjectTypeTag(SWF swf, int id, String name, ByteArrayRange data) {
         super(swf, id, name, data);
     }
 
     public abstract int getPlaceObjectNum();
-
-    public abstract int getDepth();
 
     public abstract MATRIX getMatrix();
 

--- a/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/tags/base/PlaceObjectTypeTag.java
+++ b/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/tags/base/PlaceObjectTypeTag.java
@@ -90,6 +90,8 @@ public abstract class PlaceObjectTypeTag extends Tag implements CharacterIdTag {
     public abstract void setPlaceFlagHasClipActions(boolean placeFlagHasClipActions);
 
     public abstract void setPlaceFlagHasMatrix(boolean placeFlagHasMatrix);
+    
+    public abstract void setPlaceFlagMove(boolean placeFlagMove);
 
     @Override
     public String getName() {

--- a/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/tags/base/RemoveTag.java
+++ b/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/tags/base/RemoveTag.java
@@ -24,13 +24,11 @@ import com.jpexs.helpers.ByteArrayRange;
  *
  * @author JPEXS
  */
-public abstract class RemoveTag extends Tag {
+public abstract class RemoveTag extends Tag implements DepthTag {
 
     public RemoveTag(SWF swf, int id, String name, ByteArrayRange data) {
         super(swf, id, name, data);
     }
-
-    public abstract int getDepth();
 
     @Override
     public String getName() {

--- a/src/com/jpexs/decompiler/flash/gui/CollectDepthAsSpritesDialogue.java
+++ b/src/com/jpexs/decompiler/flash/gui/CollectDepthAsSpritesDialogue.java
@@ -1,0 +1,126 @@
+/*
+ *  Copyright (C) 2010-2023 JPEXS
+ * 
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ * 
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ * 
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.jpexs.decompiler.flash.gui;
+
+import java.awt.BorderLayout;
+import java.awt.Container;
+import java.awt.Dimension;
+import java.awt.FlowLayout;
+import java.awt.Window;
+import java.awt.event.ActionEvent;
+import java.util.Collection;
+import java.util.List;
+import java.util.Vector;
+import javax.swing.BoxLayout;
+import javax.swing.JButton;
+import javax.swing.JCheckBox;
+import javax.swing.JDialog;
+import javax.swing.JLabel;
+import javax.swing.JList;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.ListSelectionModel;
+
+/**
+ *
+ * @author JPEXS
+ */
+public class CollectDepthAsSpritesDialogue extends AppDialog {
+
+    private final JButton okButton = new JButton(translate("button.ok"));
+
+    private final JButton cancelButton = new JButton(translate("button.cancel"));
+    
+    private final JList<Integer> depthsList;
+
+    private final JCheckBox replaceCheckBox;
+
+    private final JCheckBox offsetCheckBox;
+
+    private int result = ERROR_OPTION;
+
+    public CollectDepthAsSpritesDialogue(Window owner) {
+        super(owner);
+        setSize(400, 150);
+        setDefaultCloseOperation(JDialog.HIDE_ON_CLOSE);
+        Container cnt = getContentPane();
+        cnt.setLayout(new BoxLayout(cnt, BoxLayout.Y_AXIS));
+        cnt.add(new JLabel(translate("collect.depths")));
+        
+        depthsList = new JList<>();
+        depthsList.setVisibleRowCount(7);
+        depthsList.setSelectionMode(ListSelectionModel.MULTIPLE_INTERVAL_SELECTION);
+        
+        JScrollPane listScroller = new FasterScrollPane(depthsList);
+        listScroller.setPreferredSize(new Dimension(400, 200));
+        cnt.add(listScroller);
+        
+        replaceCheckBox = new JCheckBox(translate("collect.replace"));
+        cnt.add(replaceCheckBox);
+        
+        offsetCheckBox = new JCheckBox(translate("collect.offset"));
+        cnt.add(offsetCheckBox);
+
+        JPanel panButtons = new JPanel(new FlowLayout());
+        okButton.addActionListener(this::okButtonActionPerformed);
+        cancelButton.addActionListener(this::cancelButtonActionPerformed);
+        panButtons.add(okButton);
+        panButtons.add(cancelButton);
+
+        add(panButtons, BorderLayout.SOUTH);
+
+        setModalityType(ModalityType.APPLICATION_MODAL);
+        View.setWindowIcon(this);
+        setTitle(translate("dialog.title"));
+        getRootPane().setDefaultButton(okButton);
+        pack();
+        View.centerScreen(this);
+    }
+
+    private void okButtonActionPerformed(ActionEvent evt) {
+        result = OK_OPTION;
+        setVisible(false);
+    }
+
+    private void cancelButtonActionPerformed(ActionEvent evt) {
+        result = CANCEL_OPTION;
+        setVisible(false);
+    }
+
+    public List<Integer> getDepths() {
+        if (result == ERROR_OPTION) {
+            return null;
+        }
+
+        return depthsList.getSelectedValuesList();
+    }
+    
+    public boolean getReplace() {
+        return replaceCheckBox.isSelected();
+    }
+    
+    public boolean getOffset() {
+        return offsetCheckBox.isSelected();
+    }
+
+    public int showDialog(Collection<Integer> depths) {        
+        depthsList.setListData(depths.toArray(new Integer[depths.size()]));
+        depthsList.setVisibleRowCount(7);
+        setVisible(true);
+        return result;
+    }
+}

--- a/src/com/jpexs/decompiler/flash/gui/CollectDepthAsSpritesDialogue.java
+++ b/src/com/jpexs/decompiler/flash/gui/CollectDepthAsSpritesDialogue.java
@@ -24,7 +24,6 @@ import java.awt.Window;
 import java.awt.event.ActionEvent;
 import java.util.Collection;
 import java.util.List;
-import java.util.Vector;
 import javax.swing.BoxLayout;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;

--- a/src/com/jpexs/decompiler/flash/gui/CollectDepthAsSpritesDialogue.java
+++ b/src/com/jpexs/decompiler/flash/gui/CollectDepthAsSpritesDialogue.java
@@ -50,6 +50,8 @@ public class CollectDepthAsSpritesDialogue extends AppDialog {
     private final JCheckBox replaceCheckBox;
 
     private final JCheckBox offsetCheckBox;
+    
+    private final JCheckBox firstMatrixCheckBox;
 
     private int result = ERROR_OPTION;
 
@@ -74,6 +76,9 @@ public class CollectDepthAsSpritesDialogue extends AppDialog {
         
         offsetCheckBox = new JCheckBox(translate("collect.offset"));
         cnt.add(offsetCheckBox);
+        
+        firstMatrixCheckBox = new JCheckBox(translate("collect.matrix"));
+        cnt.add(firstMatrixCheckBox);
 
         JPanel panButtons = new JPanel(new FlowLayout());
         okButton.addActionListener(this::okButtonActionPerformed);
@@ -115,6 +120,10 @@ public class CollectDepthAsSpritesDialogue extends AppDialog {
     
     public boolean getOffset() {
         return offsetCheckBox.isSelected();
+    }
+    
+    public boolean getEnsureFirstMatrix() {
+        return firstMatrixCheckBox.isSelected();
     }
 
     public int showDialog(Collection<Integer> depths) {        

--- a/src/com/jpexs/decompiler/flash/gui/locales/CollectDepthAsSpritesDialogue.properties
+++ b/src/com/jpexs/decompiler/flash/gui/locales/CollectDepthAsSpritesDialogue.properties
@@ -17,6 +17,7 @@ dialog.title = Collect options
 collect.depths = Depths to collect:
 collect.replace = Replace original tags with sprite
 collect.offset = Offset top left corner to (0,0)
+collect.matrix = Use the previous frames matrix as the first PlaceObject matrix
 
 button.ok = OK
 button.cancel = Cancel

--- a/src/com/jpexs/decompiler/flash/gui/locales/CollectDepthAsSpritesDialogue.properties
+++ b/src/com/jpexs/decompiler/flash/gui/locales/CollectDepthAsSpritesDialogue.properties
@@ -1,0 +1,22 @@
+# Copyright (C) 2010-2016 JPEXS
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+dialog.title = Collect options
+collect.depths = Depths to collect:
+collect.replace = Replace original tags with sprite
+collect.offset = Offset top left corner to (0,0)
+
+button.ok = OK
+button.cancel = Cancel

--- a/src/com/jpexs/decompiler/flash/gui/locales/MainFrame.properties
+++ b/src/com/jpexs/decompiler/flash/gui/locales/MainFrame.properties
@@ -1139,3 +1139,6 @@ contextmenu.addScript.doinitaction = Add sprite init script - DoInitAction
 
 #after 18.4.1
 warning.cannotencrypt = WARNING: The file %file% was encrypted using HARMAN Air encryption.\r\nIt was successfully decrypted to be loaded, but if you want to save modified file later,\r\nthe encryption will be stripped ( = not encrypted).
+
+#after 18.5
+contextmenu.collectDepthAsSprites = Collect items at same depth as sprites

--- a/src/com/jpexs/decompiler/flash/gui/locales/MainFrame.properties
+++ b/src/com/jpexs/decompiler/flash/gui/locales/MainFrame.properties
@@ -1141,4 +1141,4 @@ contextmenu.addScript.doinitaction = Add sprite init script - DoInitAction
 warning.cannotencrypt = WARNING: The file %file% was encrypted using HARMAN Air encryption.\r\nIt was successfully decrypted to be loaded, but if you want to save modified file later,\r\nthe encryption will be stripped ( = not encrypted).
 
 #after 18.5
-contextmenu.collectDepthAsSprites = Collect items at same depth as sprites
+contextmenu.collectDepthAsSprites = Collect tags at same depth as sprites

--- a/src/com/jpexs/decompiler/flash/gui/tagtree/TagTreeContextMenu.java
+++ b/src/com/jpexs/decompiler/flash/gui/tagtree/TagTreeContextMenu.java
@@ -32,6 +32,7 @@ import com.jpexs.decompiler.flash.configuration.CustomConfigurationKeys;
 import com.jpexs.decompiler.flash.configuration.SwfSpecificCustomConfiguration;
 import com.jpexs.decompiler.flash.gui.AppDialog;
 import com.jpexs.decompiler.flash.gui.AppStrings;
+import com.jpexs.decompiler.flash.gui.CollectDepthAsSpritesDialogue;
 import com.jpexs.decompiler.flash.gui.Main;
 import com.jpexs.decompiler.flash.gui.MainPanel;
 import com.jpexs.decompiler.flash.gui.ReplaceCharacterDialog;
@@ -66,6 +67,7 @@ import com.jpexs.decompiler.flash.tags.base.CharacterIdTag;
 import com.jpexs.decompiler.flash.tags.base.CharacterTag;
 import com.jpexs.decompiler.flash.tags.base.ImageTag;
 import com.jpexs.decompiler.flash.tags.base.PlaceObjectTypeTag;
+import com.jpexs.decompiler.flash.tags.base.RemoveTag;
 import com.jpexs.decompiler.flash.tags.base.ShapeTag;
 import com.jpexs.decompiler.flash.tags.base.SoundTag;
 import com.jpexs.decompiler.flash.tags.base.TextTag;
@@ -87,6 +89,7 @@ import com.jpexs.decompiler.flash.types.CLIPACTIONRECORD;
 import com.jpexs.decompiler.flash.types.CLIPACTIONS;
 import com.jpexs.decompiler.flash.types.CXFORMWITHALPHA;
 import com.jpexs.decompiler.flash.types.HasCharacterId;
+import com.jpexs.decompiler.flash.types.MATRIX;
 import com.jpexs.decompiler.graph.CompilationException;
 import com.jpexs.decompiler.graph.DottedChain;
 import com.jpexs.helpers.Helper;
@@ -107,6 +110,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -252,6 +256,8 @@ public class TagTreeContextMenu extends JPopupMenu {
     private JMenuItem unpinAllMenuItem;
 
     private JMenuItem unpinOthersMenuItem;
+
+    private JMenuItem collectDepthAsSpritesItem;
 
     private List<TreeItem> items = new ArrayList<>();
 
@@ -531,6 +537,10 @@ public class TagTreeContextMenu extends JPopupMenu {
         pasteInsideMenuItem.setIcon(View.getIcon("paste16"));
         pasteInsideMenuItem.addActionListener(this::pasteInsideActionPerformed);
         add(pasteInsideMenuItem);
+
+        collectDepthAsSpritesItem = new JMenuItem(mainPanel.translate("contextmenu.collectDepthAsSprites"));
+        collectDepthAsSpritesItem.addActionListener(this::collectDepthAsSprites);
+        add(collectDepthAsSpritesItem);
 
         openSWFInsideTagMenuItem = new JMenuItem(mainPanel.translate("contextmenu.openswfinside"));
         openSWFInsideTagMenuItem.setIcon(View.getIcon("openinside16"));
@@ -909,6 +919,14 @@ public class TagTreeContextMenu extends JPopupMenu {
             }
         }
 
+        boolean allSelectedIsFrame = true;
+        for (TreeItem item : items) {
+            if (!(item instanceof Frame)) {
+                allSelectedIsFrame = false;
+                break;
+            }
+        }
+
         boolean hasExportableNodes = tree.hasExportableNodes();
 
         expandRecursiveMenuItem.setVisible(false);
@@ -958,6 +976,7 @@ public class TagTreeContextMenu extends JPopupMenu {
         pasteAfterMenuItem.setVisible(false);
         pasteBeforeMenuItem.setVisible(false);
         pasteInsideMenuItem.setVisible(false);
+        collectDepthAsSpritesItem.setVisible(allSelectedIsFrame && allSelectedSameParent);
         openSWFInsideTagMenuItem.setVisible(false);
         addAs12ScriptMenuItem.setVisible(false);
         addAs12FrameScriptMenuItem.setVisible(false);
@@ -2249,8 +2268,7 @@ public class TagTreeContextMenu extends JPopupMenu {
         TreePath swfPath = mainPanel.tagTree.getFullModel().getTreePath(swf);
         FolderItem scriptsNode = (FolderItem) mainPanel.tagTree.getFullModel().getScriptsNode(swf);
         TreePath scriptsPath = swfPath.pathByAddingChild(scriptsNode);
-        
-        
+
         TreePath doinitPath = scriptsPath.pathByAddingChild(doinit);
         mainPanel.tagTree.setSelectionPath(doinitPath);
         mainPanel.tagTree.scrollPathToVisible(doinitPath);
@@ -3288,6 +3306,146 @@ public class TagTreeContextMenu extends JPopupMenu {
         }
     }
 
+    private void collectDepthAsSprites(ActionEvent e) {
+        List<TreeItem> frames = getSelectedItems();
+        Timelined timelined = ((Frame) frames.get(0)).timeline.timelined;
+        SWF swf = timelined instanceof SWF ? (SWF) timelined : ((DefineSpriteTag) timelined).getSwf();
+
+        Set<Integer> originalDepths = new HashSet<>();
+
+        for (TreeItem item : frames) {
+            Frame f = (Frame) item;
+            for (Tag t : f.innerTags) {
+                if (t instanceof RemoveTag) {
+                    originalDepths.add(((RemoveTag) t).getDepth());
+                } else if (t instanceof PlaceObjectTypeTag) {
+                    originalDepths.add(((PlaceObjectTypeTag) t).getDepth());
+                }
+            }
+        }
+
+        CollectDepthAsSpritesDialogue dialog = new CollectDepthAsSpritesDialogue(Main.getDefaultDialogsOwner());
+
+        if (dialog.showDialog(originalDepths) == CollectDepthAsSpritesDialogue.OK_OPTION) {
+            List<Integer> depths = dialog.getDepths();
+            boolean replace = dialog.getReplace();
+            boolean offset = dialog.getOffset();
+
+            Map<Integer, DefineSpriteTag> sprites = new HashMap<>();
+            for (int d : depths) {
+                DefineSpriteTag sprite = new DefineSpriteTag(swf);
+                sprite.frameCount = frames.size();
+
+                for (int i = 0; i < frames.size(); i++) {
+                    Tag showFrame = new ShowFrameTag(swf);
+                    showFrame.setTimelined(sprite);
+                    sprite.addTag(showFrame);
+                }
+
+                swf.addTag(sprite);
+                sprites.put(d, sprite);
+            }
+
+            try {
+                for (int i = frames.size() - 1; i > -1; i--) {
+                    Frame f = (Frame) frames.get(i);
+                    for (int j = 0; j < f.innerTags.size(); j++) {
+                        Tag t = f.innerTags.get(j);
+                        
+                        int depth = -1;
+                        if (t instanceof RemoveTag) {
+                            depth = ((RemoveTag) t).getDepth();
+                        } else if (t instanceof PlaceObjectTypeTag) {
+                            depth = ((PlaceObjectTypeTag) t).getDepth();
+                        }
+
+                        if (depth != -1) {
+                            DefineSpriteTag sprite = sprites.get(depth);
+                            Tag clone = t.cloneTag();
+                            clone.setTimelined(sprite);
+                            sprite.addTag(i, clone);
+
+                            if (replace) {
+                                f.innerTags.remove(t);
+                                t.getTimelined().removeTag(t);
+                                swf.removeTag(t);
+                                j--;
+                            }
+                        }
+                    }
+                }
+
+                Frame first = (Frame) frames.get(0);
+
+                for (Entry<Integer, DefineSpriteTag> entry : sprites.entrySet()) {
+                    DefineSpriteTag sprite = entry.getValue();
+
+                    if (offset || replace) {
+                        int minX = Integer.MAX_VALUE;
+                        int minY = Integer.MAX_VALUE;
+
+                        for (Tag t : sprite.getTags()) {
+                            if (t instanceof PlaceObjectTypeTag) {
+                                PlaceObjectTypeTag placeTag = (PlaceObjectTypeTag) t;
+                                MATRIX m = placeTag.getMatrix();
+
+                                if (m != null) {
+                                    if (m.translateX < minX) {
+                                        minX = m.translateX;
+                                    }
+
+                                    if (m.translateY < minY) {
+                                        minY = m.translateY;
+                                    }
+                                }
+                            }
+                        }
+
+                        if (offset) {
+                            for (Tag t : sprite.getTags()) {
+                                if (t instanceof PlaceObjectTypeTag) {
+                                    PlaceObjectTypeTag placeTag = (PlaceObjectTypeTag) t;
+                                    MATRIX m = placeTag.getMatrix();
+
+                                    if (m != null) {
+                                        m.translateX -= minX;
+                                        m.translateY -= minY;
+                                    }
+                                }
+                            }
+                        }
+
+                        if (replace) {
+                            PlaceObject3Tag place = new PlaceObject3Tag(swf);
+                            place.placeFlagHasCharacter = true;
+                            place.characterId = sprite.getCharacterId();
+                            place.depth = entry.getKey();
+                            if (offset) {
+                                place.placeFlagHasMatrix = true;
+                                place.placeFlagMove = true;
+                                place.matrix = new MATRIX();
+                                place.matrix.translateX = minX;
+                                place.matrix.translateY = minY;
+                            }
+
+                            place.setTimelined(first.timeline.timelined);
+                            first.innerTags.add(place);
+                        }
+                    }
+                }
+
+                swf.updateCharacters();
+                if(replace) {
+                    swf.computeDependentCharacters();
+                    swf.computeDependentFrames();
+                }
+                mainPanel.refreshTree(swf);
+            } catch (InterruptedException | IOException ex) {
+                Logger.getLogger(TagTreeContextMenu.class.getName()).log(Level.SEVERE, null, ex);
+            }
+        }
+    }
+
     public void copyOrMoveTags(Set<TreeItem> items, boolean move, Timelined targetTimelined, Tag position) {
         Set<SWF> sourceSwfs = new LinkedHashSet<>();
         SWF targetSwf = (targetTimelined instanceof SWF) ? (SWF) targetTimelined : ((DefineSpriteTag) targetTimelined).getSwf();
@@ -3576,7 +3734,7 @@ public class TagTreeContextMenu extends JPopupMenu {
                     }
                 }
 
-                try (FileOutputStream fos = new FileOutputStream(fileName)) {
+                try ( FileOutputStream fos = new FileOutputStream(fileName)) {
                     container.getABC().saveTo(fos);
                 }
 


### PR DESCRIPTION
Allows selecting multiple frames and collecting PlaceObjectTypeTag/RemoveObjectTag with the same depth in separate sprites with options to select which depths to collect, replace the originals with the sprites and offset the characters to (0, 0) in the sprites