### PR TITLE
Implement `Utf8Helper.getAllowedCharsets()` to lazy-load `allowedCharsets`, make `Utf8Helper.allowedCharsets` private

### DIFF
--- a/libsrc/ffdec_lib/src/com/jpexs/helpers/utf8/Utf8Helper.java
+++ b/libsrc/ffdec_lib/src/com/jpexs/helpers/utf8/Utf8Helper.java
@@ -1,16 +1,16 @@
 /*
  *  Copyright (C) 2010-2023 JPEXS, All rights reserved.
- * 
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 3.0 of the License, or (at your option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library.
  */
@@ -39,16 +39,21 @@ public class Utf8Helper {
     public static String charsetName = "UTF-8";
 
     public static Charset charset = Charset.forName("UTF-8");
-    
+
     private static List<String> allowedVariableLengthCharsets = Arrays.asList(
             "GB2312", "Shift_JIS", "UTF-8", "UTF-16", "UTF16-BE", "UTF-16-LE", "UTF-32", "UTF-32LE", "UTF-32BE");
-    
-    /**
-     * Allowed charsets. They are limited to single byte charsets + allowedVariableLengthCharsets
-     */
-    public static List<String> allowedCharsets = new ArrayList<>();
 
-    static {
+    private static List<String> allowedCharsets = null;
+
+    /**
+     * Get a list of allowed charsets. They are limited to single byte charsets + allowedVariableLengthCharsets
+     */
+    public static List<String> getAllowedCharsets() {
+        if (allowedCharsets != null)
+            return allowedCharsets;
+
+        allowedCharsets = new ArrayList<>();
+
         Map<String, Charset> charsets = Charset.availableCharsets();
         for (String s : charsets.keySet()) {
             Charset charset = charsets.get(s);
@@ -56,9 +61,9 @@ public class Utf8Helper {
             int minLen = Integer.MAX_VALUE;
             try {
                 for (int i = 0; i < 65536; i++) {
-
                     ByteBuffer buf = charset.encode("" + (char) i);
                     int len = buf.remaining();
+
                     if (len > maxLen) {
                         maxLen = len;
                     }
@@ -68,12 +73,13 @@ public class Utf8Helper {
                 }
                 if ((minLen == maxLen && minLen == 1) || allowedVariableLengthCharsets.contains(s)) {
                     allowedCharsets.add(s);
-                }                    
+                }
             } catch (UnsupportedOperationException ex) {
                 //System.out.println(s + " ... ERROR");
             }
-
         }
+
+        return allowedCharsets;
     }
 
     public static String urlDecode(String s) {

--- a/src/com/jpexs/decompiler/flash/gui/tagtree/TagTreeContextMenu.java
+++ b/src/com/jpexs/decompiler/flash/gui/tagtree/TagTreeContextMenu.java
@@ -1,16 +1,16 @@
 /*
  *  Copyright (C) 2010-2023 JPEXS
- * 
+ *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
  *  the Free Software Foundation, either version 3 of the License, or
  *  (at your option) any later version.
- * 
+ *
  *  This program is distributed in the hope that it will be useful,
  *  but WITHOUT ANY WARRANTY; without even the implied warranty of
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  *  GNU General Public License for more details.
- * 
+ *
  *  You should have received a copy of the GNU General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -282,7 +282,7 @@ public class TagTreeContextMenu extends JPopupMenu {
         changeCharsetMenu = new JMenu();
         JMenu currentCharsetMenu = changeCharsetMenu;
         int charsetCnt = 0;
-        for (String charsetStr : Utf8Helper.allowedCharsets) {
+        for (String charsetStr : Utf8Helper.getAllowedCharsets()) {
             if (charsetCnt == 30) {
                 JMenu moreMenu = new JMenu(mainPanel.translate("contextmenu.more"));
                 currentCharsetMenu.add(moreMenu);
@@ -2249,8 +2249,8 @@ public class TagTreeContextMenu extends JPopupMenu {
         TreePath swfPath = mainPanel.tagTree.getFullModel().getTreePath(swf);
         FolderItem scriptsNode = (FolderItem) mainPanel.tagTree.getFullModel().getScriptsNode(swf);
         TreePath scriptsPath = swfPath.pathByAddingChild(scriptsNode);
-        
-        
+
+
         TreePath doinitPath = scriptsPath.pathByAddingChild(doinit);
         mainPanel.tagTree.setSelectionPath(doinitPath);
         mainPanel.tagTree.scrollPathToVisible(doinitPath);
@@ -2388,7 +2388,7 @@ public class TagTreeContextMenu extends JPopupMenu {
                             if (tags.get(i) instanceof DoInitActionTag) {
                                 DoInitActionTag doinit = (DoInitActionTag) tags.get(i);
                                 if (!exportedIds.contains(doinit.spriteId)) {
-                                    //this is #initpragma, make sure class is inserted before it                                
+                                    //this is #initpragma, make sure class is inserted before it
                                     insertPos = i;
                                     break;
                                 }
@@ -2831,7 +2831,7 @@ public class TagTreeContextMenu extends JPopupMenu {
     private void cloneActionPerformed(ActionEvent e) {
         List<TreeItem> items = getSelectedItems();
         /* Currently useless since all selected items must have the same parent
-        * but a better way to detect for parent/child selection 
+        * but a better way to detect for parent/child selection
         * could remove that limitation */
         Set<SWF> swfs = new HashSet<>();
 
@@ -3313,7 +3313,7 @@ public class TagTreeContextMenu extends JPopupMenu {
                         while (spriteTag.getTimelined() instanceof DefineSpriteTag) {
                             spriteTag = (DefineSpriteTag) spriteTag.getTimelined();
                         }
-                        realTargetTimelined = spriteTag.getTimelined(); //should be SWF                        
+                        realTargetTimelined = spriteTag.getTimelined(); //should be SWF
                         realPosition = spriteTag;
                     }
                 }


### PR DESCRIPTION
I've noticed that since 16.3.0, a simple instantiation of `SWF()` takes way longer than it previously did (around 2 vs .3 seconds on my computer). So I've pinpointed the issue to 4c6ccf0, which added an `allowedCharsets` static variable in `Utf8Helper` which was populated in a `static {...}` block even if it was never going to be used.

This PR implements lazy-loading of `Utf8Helper.allowedCharsets` via `Utf8Helper.getAllowedCharsets()`, so that it does not waste time generating when not needed.