### PR TITLE
FQN being used for classes in same package

### DIFF
--- a/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/abc/types/traits/Trait.java
+++ b/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/abc/types/traits/Trait.java
@@ -260,10 +260,6 @@ public abstract class Trait implements Cloneable, Serializable {
             DottedChain ipath = imports.get(i);
             String name = ipath.getLast();
             if (ipath.getWithoutLast().equals(ignorePackage)) { //do not check classes from same package, they are imported automatically
-                if (importnames.contains(name)) {
-                    fullyQualifiedNames.add(DottedChain.parseWithSuffix(name));
-                }
-                
                 imports.remove(i);
                 i--;                
                 continue;

--- a/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/abc/types/traits/TraitSlotConst.java
+++ b/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/abc/types/traits/TraitSlotConst.java
@@ -226,7 +226,7 @@ public class TraitSlotConst extends Trait implements TraitWithSlot {
         if (ignorePackage == null) {
             ignorePackage = getPackage(abc);
         }
-        super.getDependencies(abcIndex, scriptIndex, classIndex, isStatic, customNs, abc, dependencies, ignorePackage, fullyQualifiedNames);
+        super.getDependencies(abcIndex, scriptIndex, classIndex, isStatic, customNs, abc, dependencies, ignorePackage, fullyQualifiedNames); // I don't think this is necessary? It causes class variable names to be listed as dependencies, but their DottedChain consists of only 1 part, which gets categorized as a root package and filtered from imports. Unless I'm missing something, this is wrong but it doesn't break anything
         DependencyParser.parseDependenciesFromMultiname(abcIndex, customNs, abc, dependencies, abc.constants.getMultiname(type_index), getPackage(abc), fullyQualifiedNames, DependencyType.SIGNATURE);
     }
 


### PR DESCRIPTION
reverting one of the changes from [commit f81d1ac58de0e89d1c596b84a6eec6b00ffb16a6](https://github.com/jindrapetrik/jpexs-decompiler/commit/f81d1ac58de0e89d1c596b84a6eec6b00ffb16a6), because it caused the use of the FQN for classes defined within the same package

additionally added a comment on class variable names being added as dependencies, that maybe can/should be removed, but is not causing issues (I think)
