### PR TITLE
Fix incorrect quotation marks

### DIFF
--- a/resources/ffdec.sh
+++ b/resources/ffdec.sh
@@ -70,7 +70,7 @@ PROGRAM="$0"
 while [ -L "$PROGRAM" ]; do
 	PROGRAM=$(readlink -f "$PROGRAM")
 done
-pushd "$(dirname \"$PROGRAM\")" > /dev/null
+pushd "$(dirname "$PROGRAM")" > /dev/null
 
 search_jar_file || exit 1
 


### PR DESCRIPTION
With these included, the resulting path looks something like this:

    '"/app/bin'

That will always be an invalid path due to the extra double quote.