### PR TITLE
fix year being incorrect

### DIFF
--- a/src/com/jpexs/decompiler/flash/gui/ErrorLogFrame.java
+++ b/src/com/jpexs/decompiler/flash/gui/ErrorLogFrame.java
@@ -238,7 +238,7 @@ public class ErrorLogFrame extends AppFrame {
                 if (View.isOceanic()) {
                     header.setBackground(Color.white);
                 }
-                SimpleDateFormat format = new SimpleDateFormat("dd/MM/YYYY HH:mm:ss");
+                SimpleDateFormat format = new SimpleDateFormat("dd/MM/yyyy HH:mm:ss");
                 final String dateStr = format.format(new Date());
 
                 JToggleButton copyButton = new JToggleButton(View.getIcon("copy16"));


### PR DESCRIPTION
Fixes [#2172](https://www.free-decompiler.com/flash/issues/2172-log-window-thinks-that-the-year-is-2024-when-the-date-is-set-to-31-dec-2023)