### PR TITLE
Store class name index during P-code parse.

### DIFF
--- a/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/abc/avm2/parser/pcode/ASM3Parser.java
+++ b/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/abc/avm2/parser/pcode/ASM3Parser.java
@@ -286,6 +286,7 @@ public class ASM3Parser {
         }
 
         tc.slot_id = slotid;
+        tc.name_index = name_index;
 
         return true;
     }


### PR DESCRIPTION
Let's take this P-code subset:

```
trait class QName(PackageNamespace("Debug"),"Debug")
```

Currently, when changing the class name to something and saving the P-code, the original name remains unchanged.
It was due to a single missing assignment in the class parser, that this pull requests fixes.