### PR TITLE
Quote jar path in .sh script

### DIFF
--- a/resources/ffdec.sh
+++ b/resources/ffdec.sh
@@ -93,7 +93,7 @@ if [ -n "$FFDEC_MEMORY" ]; then
     MEMORY_PARAM=" -Xmx$FFDEC_MEMORY"
 fi
 
-args=(-Djava.net.preferIPv4Stack=true${MEMORY_PARAM}${STACK_SIZE_PARAM} -jar $JAR_FILE "$@")
+args=(-Djava.net.preferIPv4Stack=true${MEMORY_PARAM}${STACK_SIZE_PARAM} -jar "$JAR_FILE" "$@")
 
 if [ "$(uname)" = "Darwin" ]; then
     args=(-Xdock:name=FFDec -Xdock:icon=icon.png "${args[@]}")


### PR DESCRIPTION
The current `ffdec.sh` fails if the path to the extracted dir contains whitespaces. It can be fixed by wrapping it in quotes.