### PR TITLE
Add support for XDG base directory specification

### DIFF
--- a/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/configuration/Configuration.java
+++ b/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/configuration/Configuration.java
@@ -1061,9 +1061,24 @@ public final class Configuration {
                     String path = "Library/Application Support/" + applicationId + "/";
                     directory = new File(userHome, path);
                 } else {
-                    // ${userHome}/.${applicationId}/
-                    String path = "." + applicationId + "/";
-                    directory = new File(userHome, path);
+                    File xdgConfigHome = null;
+                    try {
+                        String xdgConfigHomeEV = System.getenv("XDG_CONFIG_HOME");
+                        if ((xdgConfigHomeEV != null) && (xdgConfigHomeEV.length() > 0)) {
+                            xdgConfigHome = new File(xdgConfigHomeEV);
+                        }
+                    } catch (SecurityException ignore) {
+                        //ignored
+                    }
+                    if ((xdgConfigHome != null) && xdgConfigHome.isDirectory()) {
+                        // ${xdgConfigHome}/${applicationId}
+                        String path = applicationId + "/";
+                        directory = new File(xdgConfigHome, path);
+                    } else {
+                        // ${userHome}/.config/${applicationId}
+                        String path = ".config/" + applicationId + "/";
+                        directory = new File(userHome, path);
+                    }
                 }
             } else {
                 //no home, then use application directory

--- a/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/configuration/Configuration.java
+++ b/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/configuration/Configuration.java
@@ -1062,6 +1062,7 @@ public final class Configuration {
                     directory = new File(userHome, path);
                 } else {
                     File xdgConfigHome = null;
+                    File oldConfigDir = new File(userHome, "." + applicationId + "/");
                     try {
                         String xdgConfigHomeEV = System.getenv("XDG_CONFIG_HOME");
                         if ((xdgConfigHomeEV != null) && (xdgConfigHomeEV.length() > 0)) {
@@ -1074,6 +1075,9 @@ public final class Configuration {
                         // ${xdgConfigHome}/${applicationId}
                         String path = applicationId + "/";
                         directory = new File(xdgConfigHome, path);
+                    } else if (oldConfigDir.isDirectory()) {
+                        // ${userHome}/.${applicationId}
+                        directory = oldConfigDir;
                     } else {
                         // ${userHome}/.config/${applicationId}
                         String path = ".config/" + applicationId + "/";


### PR DESCRIPTION
Adds support for the [XDG base directory specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) on Linux.

If `$XDG_CONFIG_HOME` environment variable is set, the config folder will be created at `$XDG_CONFIG_HOME/FFDec`. If it is not set, it will be created at `$HOME/.config/FFDec`.