### PR TITLE
MetainfoUpdater: Replace ampersand symbols with XML entity references

### DIFF
--- a/resources/com.jpexs.decompiler.flash.metainfo.xml
+++ b/resources/com.jpexs.decompiler.flash.metainfo.xml
@@ -92,7 +92,7 @@
 					<li>Script/Class initializers order of assignment</li>
 					<li>#2277 Return statement in initializer</li>
 					<li>Imports in script initializer</li>
-					<li>#2279 AS3 Decompilation - assignments on the right side of `&&` and `||` operators</li>
+					<li>#2279 AS3 Decompilation - assignments on the right side of `&amp;&amp;` and `||` operators</li>
 					<li>#2279 Embed assets with file base name ending with a space</li>
 					<li>Embed tag - Wav files need to be embedded in assets.swf</li>
 					<li>#2282 FLA export - visible flag</li>

--- a/src/com/jpexs/build/MetainfoUpdater.java
+++ b/src/com/jpexs/build/MetainfoUpdater.java
@@ -115,6 +115,7 @@ public class MetainfoUpdater {
     private static String filterLiText(String li) {
         li = li.replaceAll("\\[(#[0-9]+)\\]", "$1");
         li = li.replaceAll("\\[(PR[0-9]+)\\]", "$1");
+        li = li.replace("&", "&amp;");
         return li;
     }
 }


### PR DESCRIPTION
Otherwise Appstream metainfo validation fails whenever an ampersand is included in the changelog.