### PR TITLE
Fixed: Extreme lag when saving SWF

### DIFF
--- a/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/action/Action.java
+++ b/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/action/Action.java
@@ -183,17 +183,13 @@ public abstract class Action implements GraphSourceItem {
     /**
      * Property names list in lower case
      */
-    public static final List<String> propertyNamesListLowerCase = new AbstractList<String>() {
-        @Override
-        public String get(int index) {
-            return propertyNamesList.get(index).toLowerCase();
-        }
+    public static final List<String> propertyNamesListLowerCase = new ArrayList<>();
 
-        @Override
-        public int size() {
-            return propertyNamesList.size();
+    static {
+        for (String s : propertyNamesList) {
+            propertyNamesListLowerCase.add(s.toLowerCase());
         }
-    };
+    }
 
     /**
      * Logger

--- a/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/action/Action.java
+++ b/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/action/Action.java
@@ -83,6 +83,7 @@ import com.jpexs.helpers.Helper;
 import com.jpexs.helpers.Reference;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.AbstractList;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -182,13 +183,17 @@ public abstract class Action implements GraphSourceItem {
     /**
      * Property names list in lower case
      */
-    public static final List<String> propertyNamesListLowerCase = new ArrayList<>();
-
-    {
-        for (String s : propertyNamesList) {
-            propertyNamesListLowerCase.add(s.toLowerCase());
+    public static final List<String> propertyNamesListLowerCase = new AbstractList<String>() {
+        @Override
+        public String get(int index) {
+            return propertyNamesList.get(index).toLowerCase();
         }
-    }
+
+        @Override
+        public int size() {
+            return propertyNamesList.size();
+        }
+    };
 
     /**
      * Logger


### PR DESCRIPTION
propertyNamesListLowercase was creating a new list every time it was called, and this is a hotpath.

Replace with an AbstractList, avoiding a copy each time.

This was one of our main lag causes when editing the Anti-Idle SWF (v1861.swf https://drive.google.com/drive/u/0/folders/1yE8OxD0P0Tx1B5JyGpEaLJ7KOuayMd9s), try saving frame 4 and it took a long time. This makes the save near instant
