### PR TITLE
fix: startup warning if _JAVA_OPTIONS is set

### DIFF
--- a/resources/ffdec.sh
+++ b/resources/ffdec.sh
@@ -105,7 +105,7 @@ fi
 
 # Check default java
 if [ -x "$(which java)" ]; then
-    JAVA_VERSION_OUTPUT=$(java -version 2>&1)
+    JAVA_VERSION_OUTPUT=$(java -version 2>&1 | grep -v "Picked up _JAVA_OPTIONS")
     JAVA_VERSION_OUTPUT=$(echo $JAVA_VERSION_OUTPUT | sed 's/openjdk version/java version/')
     check_java_version && exec java "${args[@]}"
 fi
@@ -113,7 +113,7 @@ fi
 # Test other possible Java locations
 for JRE_PATH in $LOOKUP_JRE_DIRS; do
     if [ -x "$JRE_PATH/bin/java" ]; then
-        JAVA_VERSION_OUTPUT=$("$JRE_PATH/bin/java" -version 2>&1)
+        JAVA_VERSION_OUTPUT=$("$JRE_PATH/bin/java" -version 2>&1 | grep -v "Picked up _JAVA_OPTIONS")
         JAVA_VERSION_OUTPUT=`echo $JAVA_VERSION_OUTPUT | sed 's/openjdk version/java version/'`
         check_java_version && {
             export JRE_PATH


### PR DESCRIPTION
I have _JAVA_OPTIONS set in my environment and this is causing problem when checking Java versions. This PR solves the issue by filtering out this info in `java -version` output.

```sh
# .profile
export _JAVA_OPTIONS="-Djavafx.cachedir=$XDG_CACHE_HOME/openjfx"
```

With above settings, the output is problematic even if you use sed:

```sh
$ java -version
Picked up _JAVA_OPTIONS: -Djavafx.cachedir=/home/user/.cache/openjfx
openjdk version "21.0.6" 2025-01-21
OpenJDK Runtime Environment (build 21.0.6+1-void-r1)
OpenJDK 64-Bit Server VM (build 21.0.6+1-void-r1, mixed mode, sharing)
```

Warning message (the program itself runs fine though):

```
$ cd blahblah/to/ffdec
$ ./ffdec.sh
./ffdec.sh: line 47: [: Picked up _JAVA_OPTIONS: -Djavafx.cachedir=/home/user/.cache/openjfx 21: integer expression expected
./ffdec.sh: line 49: [: Picked up _JAVA_OPTIONS: -Djavafx.cachedir=/home/user/.cache/openjfx 21: integer expression expected
./ffdec.sh: line 53: [: Picked up _JAVA_OPTIONS: -Djavafx.cachedir=/home/user/.cache/openjfx 0: integer expression expected
./ffdec.sh: line 55: [: Picked up _JAVA_OPTIONS: -Djavafx.cachedir=/home/user/.cache/openjfx 0: integer expression expected
./ffdec.sh: line 59: [: Picked up _JAVA_OPTIONS: -Djavafx.cachedir=/home/user/.cache/openjfx 6: integer expression expected
./ffdec.sh: line 61: [: Picked up _JAVA_OPTIONS: -Djavafx.cachedir=/home/user/.cache/openjfx 6: integer expression expected
./ffdec.sh: line 65: [: Picked up _JAVA_OPTIONS: -Djavafx.cachedir=/home/user/.cache/openjfx : integer expression expected
Picked up _JAVA_OPTIONS: -Djavafx.cachedir=/home/user/.cache/openjfx
```

Only tested on Void Linux with OpenJDK21 installed.