### PR TITLE
Ignore all java options when checking version

### DIFF
--- a/resources/ffdec.sh
+++ b/resources/ffdec.sh
@@ -105,16 +105,16 @@ fi
 
 # Check default java
 if [ -x "$(which java)" ]; then
-    JAVA_VERSION_OUTPUT=$(java -version 2>&1 | grep -v "Picked up _JAVA_OPTIONS")
-    JAVA_VERSION_OUTPUT=$(echo $JAVA_VERSION_OUTPUT | sed 's/openjdk version/java version/')
+    JAVA_VERSION_OUTPUT=$(java -version 2>&1)
+    JAVA_VERSION_OUTPUT=$(echo $JAVA_VERSION_OUTPUT | sed -E 's/.*(openjdk|java) version/java version/')
     check_java_version && exec java "${args[@]}"
 fi
 
 # Test other possible Java locations
 for JRE_PATH in $LOOKUP_JRE_DIRS; do
     if [ -x "$JRE_PATH/bin/java" ]; then
-        JAVA_VERSION_OUTPUT=$("$JRE_PATH/bin/java" -version 2>&1 | grep -v "Picked up _JAVA_OPTIONS")
-        JAVA_VERSION_OUTPUT=`echo $JAVA_VERSION_OUTPUT | sed 's/openjdk version/java version/'`
+        JAVA_VERSION_OUTPUT=$("$JRE_PATH/bin/java" -version 2>&1)
+        JAVA_VERSION_OUTPUT=`echo $JAVA_VERSION_OUTPUT | sed -E 's/.*(openjdk|java) version/java version/'`
         check_java_version && {
             export JRE_PATH
             exec "$JRE_PATH/bin/java" "${args[@]}"


### PR DESCRIPTION
This is related to pull request #214.

That (now merged) request included a fix for filtering out the _JAVA_OPTIONS environment variable when checking the java version; however, there are other environment variables, such as JAVA_TOOL_OPTIONS, that should be filtered as well.

This pull request filters all such options, and anything else that comes before the "openjdk version" or "java version" string.

It has been tested with both BSD sed (macOS) and GNU sed (linux).