### PR TITLE
Support BSD version of sed in java version check

### DIFF
--- a/resources/ffdec.sh
+++ b/resources/ffdec.sh
@@ -39,10 +39,10 @@ search_jar_file() {
 }
 
 check_java_version () {
-    JVER1=$(echo $JAVA_VERSION_OUTPUT | sed 's/java version "\([0-9]*\)\.[0-9]*\.[0-9]*\(_[0-9]*\)\?".*/\1/')
-    JVER2=$(echo $JAVA_VERSION_OUTPUT | sed 's/java version "[0-9]*\.\([0-9]*\)\.[0-9]*\(_[0-9]*\)\?".*/\1/')
-    JVER3=$(echo $JAVA_VERSION_OUTPUT | sed 's/java version "[0-9]*\.[0-9]*\.\([0-9]*\)\(_[0-9]*\)\?".*/\1/')
-    JVER4=$(echo $JAVA_VERSION_OUTPUT | sed 's/java version "[0-9]*\.[0-9]*\.[0-9]*\(_\([0-9]*\)\)\?".*/\2/' | sed 's/^$/0/')
+    JVER1=$(echo $JAVA_VERSION_OUTPUT | sed -E 's/java version "([0-9]*)\.[0-9]*\.[0-9]*(_[0-9]*)?".*/\1/')
+    JVER2=$(echo $JAVA_VERSION_OUTPUT | sed -E 's/java version "[0-9]*\.([0-9]*)\.[0-9]*(_[0-9]*)?".*/\1/')
+    JVER3=$(echo $JAVA_VERSION_OUTPUT | sed -E 's/java version "[0-9]*\.[0-9]*\.([0-9]*)(_[0-9]*)?".*/\1/')
+    JVER4=$(echo $JAVA_VERSION_OUTPUT | sed -E 's/java version "[0-9]*\.[0-9]*\.[0-9]*(_([0-9]*))?".*/\2/' | sed 's/^$/0/')
 
     if [ "$JVER1" -gt $REQ_JVER1 ]; then
         return 0


### PR DESCRIPTION
On macOS, the `ffdec.sh` script fails to determine the version of java installed; it prints out several "integer expression expected" error messages, such as:

> dist/ffdec.sh: line 47: [: java version "24.0.1" 2025-04-15 OpenJDK Runtime Environment Temurin-24.0.1+9 (build 24.0.1+9) OpenJDK 64-Bit Server VM Temurin-24.0.1+9 (build 24.0.1+9, mixed mode, sharing): integer expression expected

The issue is that the `check_java_version` function in `ffdec.sh` uses a regular expression that works with GNU sed, but is not compatible with BSD sed.

This pull request replaces the above-mentioned regular expression with one that works with both sed flavors.