### PR TITLE
Resolve crash when performing -replace on AS3 scripts

### DIFF
--- a/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/abc/avm2/parser/script/AbcIndexing.java
+++ b/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/abc/avm2/parser/script/AbcIndexing.java
@@ -1104,6 +1104,11 @@ public final class AbcIndexing {
      */
     protected void indexTraits(ABC abc, int name_index, Traits ts, Map<PropertyDef, TraitIndex> map, Map<PropertyNsDef, TraitIndex> mapNs, Map<AmbiguousPropertyDef, List<TraitIndex>> mapAmbiguous, int scriptIndex) {        
         for (Trait t : ts.traits) {
+            // Skip any stale traits that were left over from delete/replace
+            if (t.name_index < 0 || t.name_index >= abc.constants.getMultinameCount()) {
+                continue;
+            }
+            
             ValueKind propValue = null;
             if (t instanceof TraitSlotConst) {
                 TraitSlotConst tsc = (TraitSlotConst) t;
@@ -1235,6 +1240,12 @@ public final class AbcIndexing {
                 Trait tr = abc.script_info.get(i).traits.traits.get(t);
                 if (tr instanceof TraitClass) {
                     TraitClass tc = (TraitClass) tr;
+                    
+                    // Skip any stale traits that were left over from delete/replace
+                    if (tc.name_index < 0 || tc.name_index >= abc.constants.getMultinameCount()) {
+                        continue;
+                    }
+                    
                     InstanceInfo ii = abc.instance_info.get(tc.class_info);
                     if (ii.deleted) {
                         continue;


### PR DESCRIPTION
This fix was created by a mod author (**ttam**) on Nexus. I am proposing this fix on their behalf.

From their notes:

> When JPEXS replaces a script, it calls `pack.delete(abc, true)` to remove the old script from the ABC bytecode. That deletion invalidates the constant pool. Multiname indices that other traits were pointing to are now stale. Then JPEXS calls `refreshAbc()` -> `addAbc()` -> `indexTraits()`, which iterates over ALL traits in the ABC (not just the one you replaced). Some of those other traits still have `name_index` values pointing to the old constant pool positions. When it does `abc.constants.getMultiname(t.name_index)`, the index is out of bounds -> `IndexOutOfBoundsException` -> crash.

>Those stale traits are from deleted/replaced scripts that haven't been cleaned up yet. Skipping them during indexing is safe because they're dead code - they'll never be referenced again. The actual replacement script gets compiled fresh with valid indices.