### PR TITLE
Translator: autosave on exit checkbox

### DIFF
--- a/src/com/jpexs/decompiler/flash/gui/translator/Translator.java
+++ b/src/com/jpexs/decompiler/flash/gui/translator/Translator.java
@@ -74,6 +74,7 @@ import java.util.zip.ZipOutputStream;
 import javax.swing.AbstractCellEditor;
 import javax.swing.DefaultComboBoxModel;
 import javax.swing.JButton;
+import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
 import javax.swing.JFileChooser;
 import javax.swing.JFrame;
@@ -117,6 +118,9 @@ public class Translator extends JFrame implements ItemListener {
     private DefaultTableModel tableModel;
     private JComboBox<LocaleItem> localeComboBox;
     private JComboBox<ResourceItem> resourcesComboBox;
+
+    private boolean autosaveOnExit = true;
+    private JCheckBox autosaveCheckBox;
 
     private String lastSaveDir = "";
 
@@ -318,7 +322,9 @@ public class Translator extends JFrame implements ItemListener {
             @Override
             public void windowClosing(WindowEvent e) {
                 try {
-                    save();
+                    if (autosaveOnExit) {
+                        save();
+                    }
                     saveWindow();
                 } catch (IOException ex) {
                     Logger.getLogger(Translator.class.getName()).log(Level.SEVERE, null, ex);
@@ -729,11 +735,24 @@ public class Translator extends JFrame implements ItemListener {
                 }
             }
         });
+
+        autosaveCheckBox = new JCheckBox("Autosave on exit", true);
+        autosaveCheckBox.addItemListener(new ItemListener() {
+            @Override
+            public void itemStateChanged(ItemEvent e) {
+                autosaveOnExit = autosaveCheckBox.isSelected();
+            }
+        });
+
         buttonsPanel.add(importButton);
         buttonsPanel.add(exportButton);
         buttonsPanel.add(startOverButton);
 
-        cnt.add(buttonsPanel, BorderLayout.SOUTH);
+        JPanel bottomPanel = new JPanel(new BorderLayout());
+        bottomPanel.add(buttonsPanel, BorderLayout.CENTER);
+        bottomPanel.add(autosaveCheckBox, BorderLayout.EAST);
+
+        cnt.add(bottomPanel, BorderLayout.SOUTH);
 
         cnt.add(new JScrollPane(table), BorderLayout.CENTER);
         resizeColumnWidth(table);
@@ -1108,6 +1127,10 @@ public class Translator extends JFrame implements ItemListener {
                 case "export.dir":
                     lastSaveDir = value;
                     break;
+                case "autosave":
+                    autosaveOnExit = value.equals("true");
+                    autosaveCheckBox.setSelected(autosaveOnExit);
+                    break;
             }
 
         }
@@ -1133,6 +1156,7 @@ public class Translator extends JFrame implements ItemListener {
         pw.println("column.en.width=" + table.getColumn("en").getWidth());
         pw.println("column.translated.width=" + table.getColumn("translated").getWidth());
         pw.println("export.dir=" + lastSaveDir);
+        pw.println("autosave=" + autosaveOnExit);
 
         writer.close();
     }


### PR DESCRIPTION
Translator is autosaving ...FFDec/translated.zip . I decided to not do that. So I added an 'Autosave on exit' checkbox.

<img width="1856" height="53" alt="Screenshot From 2026-05-06 07-12-51" src="https://github.com/user-attachments/assets/d3eb8b36-094c-4331-a164-0637e9eece7e" />

By the way, if not like this I will 'cp' a stored translation every launch to config. Maybe this is causing my last comment from here:
https://www.free-decompiler.com/flash/issues/2577-problem-with-translator
After 'cp' I also do a 'sync' but who knows...