### PR TITLE
loading spinner config

### DIFF
--- a/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/configuration/Configuration.java
+++ b/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/configuration/Configuration.java
@@ -1237,6 +1237,10 @@ public final class Configuration {
     @ConfigurationCategory("display")
     public static ConfigurationItem<Boolean> useMinimumStrokeWidth1Px = null;
     
+    @ConfigurationDefaultBoolean(true)
+    @ConfigurationCategory("display")
+    public static ConfigurationItem<Boolean> showLoadingSpinner = null;
+
     private static Map<String, String> configurationDescriptions = new LinkedHashMap<>();
     private static Map<String, String> configurationTitles = new LinkedHashMap<>();
 

--- a/src/com/jpexs/decompiler/flash/gui/MainFrameStatusPanel.java
+++ b/src/com/jpexs/decompiler/flash/gui/MainFrameStatusPanel.java
@@ -16,6 +16,7 @@
  */
 package com.jpexs.decompiler.flash.gui;
 
+import com.jpexs.decompiler.flash.configuration.Configuration;
 import com.jpexs.helpers.CancellableWorker;
 import java.awt.BorderLayout;
 import java.awt.Cursor;
@@ -81,8 +82,10 @@ public class MainFrameStatusPanel extends JPanel {
             if (w != null) {           
                 w.userCancel(true);
             }
-        });                               
-        statusLeftPanel.add(loadingPanel);
+        });
+        if (Configuration.showLoadingSpinner.get()) {
+            statusLeftPanel.add(loadingPanel);
+        }
         statusLeftPanel.add(cancelButton);
         statusLeftPanel.add(statusLabel);
         setPreferredSize(new Dimension(1, 30));
@@ -131,19 +134,23 @@ public class MainFrameStatusPanel extends JPanel {
     }
 
     public void showOldStatus() {
-        if (oldStatus.isEmpty()) {
-            loadingPanel.setVisible(false);
-        } else {
-            loadingPanel.setVisible(true);
+        if (Configuration.showLoadingSpinner.get()) {
+            if (oldStatus.isEmpty()) {
+                loadingPanel.setVisible(false);
+            } else {
+                loadingPanel.setVisible(true);
+            }
         }
         statusLabel.setText(oldStatus);
     }
 
     public void setWorkStatus(String s, CancellableWorker worker) {
-        if (s.isEmpty()) {
-            loadingPanel.setVisible(false);
-        } else {
-            loadingPanel.setVisible(true);
+        if (Configuration.showLoadingSpinner.get()) {
+            if (s.isEmpty()) {
+                loadingPanel.setVisible(false);
+            } else {
+                loadingPanel.setVisible(true);
+            }
         }
         statusLabel.setText(s);
         currentWorker = worker;

--- a/src/com/jpexs/decompiler/flash/gui/locales/AdvancedSettingsDialog.properties
+++ b/src/com/jpexs/decompiler/flash/gui/locales/AdvancedSettingsDialog.properties
@@ -694,3 +694,7 @@ config.description.msaaGridForExport = Multi sample Anti-aliasing grid size NxN 
 
 config.name.useMinimumStrokeWidth1Px = Minimum stroke width of 1 pixel (As in Flash)
 config.description.useMinimumStrokeWidth1Px = Use 1 pixel as minimal stroke width. Flash renders strokes this way. Turn this off to allow thinner strokes.
+
+#after 26.0.0
+config.name.showLoadingSpinner = Show loading spinner
+config.description.showLoadingSpinner = Displays animated loading indicator in status bar


### PR DESCRIPTION
This is how is now:
<img width="484" height="45" alt="Screenshot From 2026-05-07 13-43-43" src="https://github.com/user-attachments/assets/15bdef2f-0e76-4958-9aa9-65a755f7f99a" />
On Raspberry Pi it is hard to debug with than spinning animation.
Added a 'Show loading spinner' in check box in AdvancedSettingsDialog which is avoiding ```statusLeftPanel.add(loadingPanel);``` and two more ```loadingPanel.setVisible```. I left one ```loadingPanel.setVisible(false)``` untouched.
The cpu load is now acceptable on Raspberry Pi.