### PR TITLE
Fix UI scale not updating when switching to a lower-DPI monitor

### DIFF
--- a/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/configuration/Configuration.java
+++ b/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/configuration/Configuration.java
@@ -823,7 +823,7 @@ public final class Configuration {
     @ConfigurationCategory("script")
     public static ConfigurationItem<Boolean> flattenASPackages = null;
 
-    @ConfigurationDefaultDouble(1.0)
+    //@ConfigurationDefaultDouble(1.0)
     @ConfigurationCategory("display")
     @ConfigurationName("gui.scale")
     public static ConfigurationItem<Double> uiScale = null;

--- a/src/com/jpexs/decompiler/flash/gui/Main.java
+++ b/src/com/jpexs/decompiler/flash/gui/Main.java
@@ -2971,16 +2971,19 @@ public class Main {
         System.setProperty("sun.java2d.d3d", "false");
         System.setProperty("sun.java2d.noddraw", "true");
 
-        if (System.getProperty("sun.java2d.uiScale") == null) { //it was not set by commandline, etc.       
+        if (System.getProperty("sun.java2d.uiScale") == null) { //it was not set by commandline, etc.
+            double scaleToUse = Configuration.uiScale.get();
             if (!Configuration.uiScale.hasValue()) {
+                // Auto-detect from current screen. Do NOT persist to config so the scale is
+                // re-detected on each launch (prevents stale 4K scale being applied on a
+                // lower-DPI monitor after a display change).
                 GraphicsConfiguration configuration = View.getMainDefaultScreenDevice().getDefaultConfiguration();
-
                 AffineTransform transform = configuration.getDefaultTransform();
                 if (transform != null) {
-                    Configuration.uiScale.set(transform.getScaleX());
+                    scaleToUse = transform.getScaleX();
                 }
             }
-            System.setProperty("sun.java2d.uiScale", "" + Configuration.uiScale.get());
+            System.setProperty("sun.java2d.uiScale", "" + scaleToUse);
         }
 
         if (Configuration.hwAcceleratedGraphics.get()) {

--- a/src/com/jpexs/decompiler/flash/gui/Main.java
+++ b/src/com/jpexs/decompiler/flash/gui/Main.java
@@ -2973,7 +2973,7 @@ public class Main {
 
         if (System.getProperty("sun.java2d.uiScale") == null) { //it was not set by commandline, etc.
             double scaleToUse = Configuration.uiScale.get();
-            if (!Configuration.uiScale.hasValue()) {
+            if (!Configuration.uiScale.hasValue() || Configuration.uiScale.get() == null) {
                 // Auto-detect from current screen. Do NOT persist to config so the scale is
                 // re-detected on each launch (prevents stale 4K scale being applied on a
                 // lower-DPI monitor after a display change).


### PR DESCRIPTION
I ran into this on a dual-monitor setup, had FFDec open on a 4K monitor, then switched to a regular 1080p monitor and the UI was massive, couldn't click anything. jpexs saves the detected DPI scale to config on first launch. Next time it sees a saved value and skips detection entirely, so it stays at 4K scale even on a lower-DPI screen.

Fix: stop saving the auto-detected scale to config. It now re-detects from the current screen on every launch. Manually configured gui.scale in settings is still respected.

Note: if you've hit this bug before, you may have a stale gui.scale entry in your project.properties config file. Deleting that line will let the fix take effect.