### PR TITLE
fix(as2): correct Decrement cast and guard empty output in ActionSetMember

### DIFF
--- a/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/action/swf5/ActionSetMember.java
+++ b/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/action/swf5/ActionSetMember.java
@@ -188,7 +188,7 @@ public class ActionSetMember extends Action {
                             ((GetMemberActionItem) ((DecrementActionItem) value).object).object = ((GetMemberActionItem) ((DecrementActionItem) value).object).object.getThroughDuplicate();
                             cleanupTemp(((GetMemberActionItem) ((DecrementActionItem) value).object).object, object, output, stack);                            
                             if (setter) {
-                                stack.addToOutput(new PreDecrementActionItem(action, lineStartAction, ((IncrementActionItem) value).object.getThroughDuplicate()));
+                                stack.addToOutput(new PreDecrementActionItem(action, lineStartAction, ((DecrementActionItem) value).object.getThroughDuplicate()));
                             } else {
                                 stack.addToOutput(new PostDecrementActionItem(action, lineStartAction, ((DecrementActionItem) value).object.getThroughDuplicate()));
                             }
@@ -252,8 +252,14 @@ public class ActionSetMember extends Action {
         } finally {
             if (setter) {
                 stack.finishBlock(output);
-                stack.push(output.remove(output.size() - 1));
-                stack.moveToStack(output);
+                // Guard against an empty output: if the try block exited via an
+                // exception before producing a statement, removing from an empty
+                // list would throw IndexOutOfBoundsException here and mask the
+                // original exception. Mirrors the check used in cleanupTemp().
+                if (!output.isEmpty()) {
+                    stack.push(output.remove(output.size() - 1));
+                    stack.moveToStack(output);
+                }
             }
         }
     }


### PR DESCRIPTION
## Problem

`ActionSetMember.handleSetMember` crashes when decompiling AS2 code that applies `--` to a *virtual* property — one defined via `addProperty` with `__get__`/`__set__` accessors, e.g.:

```actionscript
this.Position--;   // compiles to __get__Position() / Decrement / __set__Position(...)
```

The reported error is always:

```
java.lang.IndexOutOfBoundsException: Index -1 out of bounds for length 0
    at java.util.ArrayList.remove(ArrayList.java:551)
    at com.jpexs.decompiler.graph.GraphPartMarkedArrayList.remove(GraphPartMarkedArrayList.java:199)
    at com.jpexs.decompiler.flash.action.swf5.ActionSetMember.handleSetMember(ActionSetMember.java:255)
    at com.jpexs.decompiler.flash.action.swf5.ActionCallMethod.translate(ActionCallMethod.java:113)
    ...
```

Because `deobfuscateIdentifiers` decompiles every script on load when **"automatically rename identifiers"** is enabled (the default), this aborts opening the whole SWF, not just one script.

## Root cause

The `IndexOutOfBoundsException` is a red herring. The real bug is a copy-paste error in the decrement→`PreDecrement` setter branch, which casts `value` to `IncrementActionItem` inside the `DecrementActionItem` block:

```java
stack.addToOutput(new PreDecrementActionItem(action, lineStartAction,
        ((IncrementActionItem) value).object.getThroughDuplicate())); // ClassCastException
```

That `ClassCastException` is thrown while evaluating the argument, *before* `addToOutput` runs, so `output` stays empty. The exception then propagates into the `finally`, which unconditionally runs `output.remove(output.size() - 1)` on the empty list — throwing `IndexOutOfBoundsException` and **replacing** the original `ClassCastException`. The true cause is never surfaced.

## Fix

1. Cast `value` to `DecrementActionItem` (matching every other reference in that branch).
2. Guard the `finally` against an empty `output`, mirroring the existing `!output.isEmpty()` check in `cleanupTemp()`, so a future exception in the `try` block is no longer masked by a misleading `IndexOutOfBoundsException`.

## Verification

Reproduced with a real AS2 SWF whose `ArrayList`/`PagesChangerController` classes use `Position++`/`Position--` and `currentPage++`/`currentPage--` on virtual properties. Built `ffdec_lib` with the patch and ran against it:

- `-swf2xml` with default settings (auto-rename on): previously crashed, now exits 0.
- `-export script`: previously 2 scripts failed with the decompilation-error stub, now **0 errors**.
- The affected methods decompile to the correct `++this.Position` / `--this.currentPage` form.