### PR TITLE
Optimizing AS3 compilation for very large files

### DIFF
--- a/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/abc/avm2/parser/script/AVM2SourceGenerator.java
+++ b/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/abc/avm2/parser/script/AVM2SourceGenerator.java
@@ -116,9 +116,11 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
@@ -2539,7 +2541,6 @@ public class AVM2SourceGenerator implements SourceGenerator {
      * @return True if found
      */
     public static boolean searchPrototypeChain(String nsKeyword, Integer namespaceSuffix, List<Integer> otherNs, int privateNs, int protectedNs, int staticProtectedNs, int internalNs, boolean instanceOnly, AbcIndexing abc, DottedChain pkg, String obj, String propertyName, Reference<String> outName, Reference<DottedChain> outNs, Reference<DottedChain> outPropNs, Reference<Integer> outPropNsKind, Reference<Integer> outPropNsIndex, Reference<GraphTargetItem> outPropType, Reference<ValueKind> outPropValue, Reference<ABC> outPropValueAbc, Reference<Boolean> isType, Reference<Trait> outPropTrait) {
-        
         AVM2ConstantPool constants = abc.getSelectedAbc().constants;
         int publicNs = constants.getNamespaceId(Namespace.KIND_PACKAGE, "", 0, false);
         
@@ -2580,12 +2581,71 @@ public class AVM2SourceGenerator implements SourceGenerator {
         return searchPrototypeChain(publicNs, instanceOnly, abc, pkg, obj, propertyName, outName, outNs, outPropNs, outPropNsKind, outPropNsIndex, outPropType, outPropValue, outPropValueAbc, isType, outPropTrait);
     }
 
+    private static LinkedHashMap<AbcFindPropertyKey, AbcIndexing.TraitIndex> abcFindPropertyCache = new LinkedHashMap<AbcFindPropertyKey, AbcIndexing.TraitIndex>(10, 0.75f, true) {
+        @Override
+        protected boolean removeEldestEntry(Map.Entry<AbcFindPropertyKey, AbcIndexing.TraitIndex> eldest) {
+            return size() > 100;
+        }
+    };
+
+    private static class AbcFindPropertyKey {
+        public AbcIndexing abc;
+        public String propertyName;
+        public DottedChain pkg;
+        public String obj;
+        public ABC selectedAbc;
+        public int selectedNs;
+        public boolean instanceOnly;
+
+        public AbcFindPropertyKey(AbcIndexing abc, String propertyName, DottedChain pkg, String obj, ABC selectedAbc, int selectedNs, boolean instanceOnly) {
+            this.abc = abc;
+            this.propertyName = propertyName;
+            this.pkg = pkg;
+            this.obj = obj;
+            this.selectedAbc = selectedAbc;
+            this.selectedNs = selectedNs;
+            this.instanceOnly = instanceOnly;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            AbcFindPropertyKey that = (AbcFindPropertyKey) o;
+            return this.abc == that.abc
+                    && this.selectedAbc == that.selectedAbc
+                    && this.selectedNs == that.selectedNs
+                    && this.instanceOnly == that.instanceOnly
+                    && Objects.equals(this.propertyName, that.propertyName)
+                    && Objects.equals(this.pkg, that.pkg)
+                    && Objects.equals(this.obj, that.obj);
+        }
+        
+        @Override
+        public int hashCode() {
+            return Objects.hash(abc, propertyName, pkg, obj, selectedAbc, selectedNs, instanceOnly);
+        }
+    }
+
     private static boolean searchPrototypeChain(int selectedNs, boolean instanceOnly, AbcIndexing abc, DottedChain pkg, String obj, String propertyName, Reference<String> outName, Reference<DottedChain> outNs, Reference<DottedChain> outPropNs, Reference<Integer> outPropNsKind, Reference<Integer> outPropNsIndex, Reference<GraphTargetItem> outPropType, Reference<ValueKind> outPropValue, Reference<ABC> outPropValueAbc, Reference<Boolean> isType, Reference<Trait> outPropTrait) {
         isType.setVal(false);
         AbcIndexing.TraitIndex sp = abc.findScriptProperty(pkg.addWithSuffix(propertyName));
+
         if (sp == null) {
-            Reference<Boolean> foundStatic = new Reference<>(null);               
-            sp = abc.findProperty(new AbcIndexing.PropertyDef(propertyName, new TypeItem(pkg.addWithSuffix(obj)), abc.getSelectedAbc(), selectedNs), !instanceOnly, true, true, foundStatic);
+            AbcFindPropertyKey key = new AbcFindPropertyKey(abc, propertyName, pkg, obj, abc.getSelectedAbc(), selectedNs, instanceOnly);
+
+            if (abcFindPropertyCache.containsKey(key)) {
+                sp = abcFindPropertyCache.get(key);
+            } else {
+                Reference<Boolean> foundStatic = new Reference<>(null);
+
+                sp = abc.findProperty(new AbcIndexing.PropertyDef(propertyName, new TypeItem(pkg.addWithSuffix(obj)), abc.getSelectedAbc(), selectedNs), !instanceOnly, true, true, foundStatic);
+                abcFindPropertyCache.put(key, sp);
+            }
         }
         if (sp != null) {
             if (sp.trait instanceof TraitClass) {


### PR DESCRIPTION
Proof of concept for optimizing AS3 replace. A game I'm modding has an extremely large MainTimeline AS3 file, compiling the file takes minutes each time.

Digging through Flight Recorder capture in VisualVM, the main culprit is somewhere in `AVM2SourceGenerator` repeatedly running `AVM2SourceGenerator.searchPrototypeChain`, which then calls `AbcIndexing.findProperty`.
After logging function calls, I noticed that the functions keep getting called to lookup the exact same thing over and over.
So I added a LRU cache inside `searchPrototypeChain` before `AbcIndexing.findProperty`, memoizing the return values.
This will definitely need a cleanup, but the core idea works.

Results: 
I've tested on two different SWFs and scripts
First one ActionScript3Parser.compile total time from 64.6s to 9.4s
Second ActionScript3Parser.compile total time from 250.9s to 48.3s