### PR TITLE
Optimize UnresolvedAVM2Item.resolve for replaceAS3 of very large files

### DIFF
--- a/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/abc/avm2/parser/script/AVM2SourceGenerator.java
+++ b/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/abc/avm2/parser/script/AVM2SourceGenerator.java
@@ -109,6 +109,7 @@ import com.jpexs.decompiler.graph.model.SwitchItem;
 import com.jpexs.decompiler.graph.model.TernarOpItem;
 import com.jpexs.decompiler.graph.model.TrueItem;
 import com.jpexs.decompiler.graph.model.WhileItem;
+import com.jpexs.helpers.LRULinkedHashMap;
 import com.jpexs.helpers.Reference;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -2583,12 +2584,7 @@ public class AVM2SourceGenerator implements SourceGenerator {
         return searchPrototypeChain(publicNs, instanceOnly, abc, pkg, obj, propertyName, outName, outNs, outPropNs, outPropNsKind, outPropNsIndex, outPropType, outPropValue, outPropValueAbc, isType, outPropTrait);
     }
 
-    private static LinkedHashMap<AbcFindPropertyKey, AbcIndexing.TraitIndex> abcFindPropertyCache = new LinkedHashMap<AbcFindPropertyKey, AbcIndexing.TraitIndex>(10, 0.75f, true) {
-        @Override
-        protected boolean removeEldestEntry(Map.Entry<AbcFindPropertyKey, AbcIndexing.TraitIndex> eldest) {
-            return size() > 100;
-        }
-    };
+    private static LinkedHashMap<AbcFindPropertyKey, AbcIndexing.TraitIndex> abcFindPropertyCache = new LRULinkedHashMap<>(100);
 
     private static class AbcFindPropertyKey {
         public AbcIndexing abc;

--- a/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/abc/avm2/parser/script/AVM2SourceGenerator.java
+++ b/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/abc/avm2/parser/script/AVM2SourceGenerator.java
@@ -1196,13 +1196,15 @@ public class AVM2SourceGenerator implements SourceGenerator {
 
         localData.activationReg = 0;
 
+        UnresolvedAVM2Item.ResolveAccelerator accelerator = new UnresolvedAVM2Item.ResolveAccelerator(subvariables);
+
         for (int i = 0; i < subvariables.size(); i++) {
             AssignableAVM2Item an = subvariables.get(i);
             if (an instanceof UnresolvedAVM2Item) {
                 UnresolvedAVM2Item n = (UnresolvedAVM2Item) an;
                 if (n.resolved == null) {
                     String fullClass = localData.getFullClass();
-                    GraphTargetItem res = n.resolve(localData, fullClass, new TypeItem(fullClass), paramTypes, paramNames, abcIndex, callStack, subvariables);
+                    GraphTargetItem res = n.resolve(localData, fullClass, new TypeItem(fullClass), paramTypes, paramNames, abcIndex, callStack, subvariables, accelerator);
                     if (res instanceof AssignableAVM2Item) {
                         subvariables.set(i, (AssignableAVM2Item) res);
                     } else {
@@ -1219,7 +1221,7 @@ public class AVM2SourceGenerator implements SourceGenerator {
                 UnresolvedAVM2Item n = (UnresolvedAVM2Item) an;
                 if (n.resolved == null) {
                     String fullClass = localData.getFullClass();
-                    GraphTargetItem res = n.resolve(localData, fullClass, new TypeItem(fullClass), paramTypes, paramNames, abcIndex, callStack, subvariables);
+                    GraphTargetItem res = n.resolve(localData, fullClass, new TypeItem(fullClass), paramTypes, paramNames, abcIndex, callStack, subvariables, accelerator);
                     paramTypes.set(t, res);
                 }
             }

--- a/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/abc/avm2/parser/script/AVM2SourceGenerator.java
+++ b/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/abc/avm2/parser/script/AVM2SourceGenerator.java
@@ -116,9 +116,11 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
@@ -2539,7 +2541,6 @@ public class AVM2SourceGenerator implements SourceGenerator {
      * @return True if found
      */
     public static boolean searchPrototypeChain(String nsKeyword, Integer namespaceSuffix, List<Integer> otherNs, int privateNs, int protectedNs, int staticProtectedNs, int internalNs, boolean instanceOnly, AbcIndexing abc, DottedChain pkg, String obj, String propertyName, Reference<String> outName, Reference<DottedChain> outNs, Reference<DottedChain> outPropNs, Reference<Integer> outPropNsKind, Reference<Integer> outPropNsIndex, Reference<GraphTargetItem> outPropType, Reference<ValueKind> outPropValue, Reference<ABC> outPropValueAbc, Reference<Boolean> isType, Reference<Trait> outPropTrait) {
-        
         AVM2ConstantPool constants = abc.getSelectedAbc().constants;
         int publicNs = constants.getNamespaceId(Namespace.KIND_PACKAGE, "", 0, false);
         
@@ -2580,12 +2581,71 @@ public class AVM2SourceGenerator implements SourceGenerator {
         return searchPrototypeChain(publicNs, instanceOnly, abc, pkg, obj, propertyName, outName, outNs, outPropNs, outPropNsKind, outPropNsIndex, outPropType, outPropValue, outPropValueAbc, isType, outPropTrait);
     }
 
+    private static LinkedHashMap<AbcFindPropertyKey, AbcIndexing.TraitIndex> abcFindPropertyCache = new LinkedHashMap<AbcFindPropertyKey, AbcIndexing.TraitIndex>(10, 0.75f, true) {
+        @Override
+        protected boolean removeEldestEntry(Map.Entry<AbcFindPropertyKey, AbcIndexing.TraitIndex> eldest) {
+            return size() > 100;
+        }
+    };
+
+    private static class AbcFindPropertyKey {
+        public AbcIndexing abc;
+        public String propertyName;
+        public DottedChain pkg;
+        public String obj;
+        public ABC selectedAbc;
+        public int selectedNs;
+        public boolean instanceOnly;
+
+        public AbcFindPropertyKey(AbcIndexing abc, String propertyName, DottedChain pkg, String obj, ABC selectedAbc, int selectedNs, boolean instanceOnly) {
+            this.abc = abc;
+            this.propertyName = propertyName;
+            this.pkg = pkg;
+            this.obj = obj;
+            this.selectedAbc = selectedAbc;
+            this.selectedNs = selectedNs;
+            this.instanceOnly = instanceOnly;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            AbcFindPropertyKey that = (AbcFindPropertyKey) o;
+            return this.abc == that.abc
+                    && this.selectedAbc == that.selectedAbc
+                    && this.selectedNs == that.selectedNs
+                    && this.instanceOnly == that.instanceOnly
+                    && Objects.equals(this.propertyName, that.propertyName)
+                    && Objects.equals(this.pkg, that.pkg)
+                    && Objects.equals(this.obj, that.obj);
+        }
+        
+        @Override
+        public int hashCode() {
+            return Objects.hash(abc, propertyName, pkg, obj, selectedAbc, selectedNs, instanceOnly);
+        }
+    }
+
     private static boolean searchPrototypeChain(int selectedNs, boolean instanceOnly, AbcIndexing abc, DottedChain pkg, String obj, String propertyName, Reference<String> outName, Reference<DottedChain> outNs, Reference<DottedChain> outPropNs, Reference<Integer> outPropNsKind, Reference<Integer> outPropNsIndex, Reference<GraphTargetItem> outPropType, Reference<ValueKind> outPropValue, Reference<ABC> outPropValueAbc, Reference<Boolean> isType, Reference<Trait> outPropTrait) {
         isType.setVal(false);
         AbcIndexing.TraitIndex sp = abc.findScriptProperty(pkg.addWithSuffix(propertyName));
+
         if (sp == null) {
-            Reference<Boolean> foundStatic = new Reference<>(null);               
-            sp = abc.findProperty(new AbcIndexing.PropertyDef(propertyName, new TypeItem(pkg.addWithSuffix(obj)), abc.getSelectedAbc(), selectedNs), !instanceOnly, true, true, foundStatic);
+            AbcFindPropertyKey key = new AbcFindPropertyKey(abc, propertyName, pkg, obj, abc.getSelectedAbc(), selectedNs, instanceOnly);
+
+            if (abcFindPropertyCache.containsKey(key)) {
+                sp = abcFindPropertyCache.get(key);
+            } else {
+                Reference<Boolean> foundStatic = new Reference<>(null);
+
+                sp = abc.findProperty(new AbcIndexing.PropertyDef(propertyName, new TypeItem(pkg.addWithSuffix(obj)), abc.getSelectedAbc(), selectedNs), !instanceOnly, true, true, foundStatic);
+                abcFindPropertyCache.put(key, sp);
+            }
         }
         if (sp != null) {
             if (sp.trait instanceof TraitClass) {

--- a/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/abc/avm2/parser/script/PropertyAVM2Item.java
+++ b/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/abc/avm2/parser/script/PropertyAVM2Item.java
@@ -40,6 +40,7 @@ import com.jpexs.decompiler.graph.GraphTargetItem;
 import com.jpexs.decompiler.graph.SourceGenerator;
 import com.jpexs.decompiler.graph.TypeItem;
 import com.jpexs.decompiler.graph.model.LocalData;
+import com.jpexs.helpers.LRULinkedHashMap;
 import com.jpexs.helpers.Reference;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -518,20 +519,6 @@ public class PropertyAVM2Item extends AssignableAVM2Item {
         return null;
     }
 
-
-    private static class LRULinkedHashMap<K, V> extends LinkedHashMap<K, V> {
-        private final int maxEntries;
-
-        public LRULinkedHashMap(int maxEntries) {
-            super(maxEntries + 1, 1.0f, true);
-            this.maxEntries = maxEntries;
-        }
-
-        @Override
-        protected boolean removeEldestEntry(Map.Entry<K, V> eldest) {
-            return size() > maxEntries;
-        }
-    }
 
     private static class ResolveNameIndexKey {
         int nsindex;

--- a/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/abc/avm2/parser/script/PropertyAVM2Item.java
+++ b/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/abc/avm2/parser/script/PropertyAVM2Item.java
@@ -46,8 +46,10 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -153,6 +155,12 @@ public class PropertyAVM2Item extends AssignableAVM2Item {
         return abc.getSelectedAbc().constants.getNamespaceSetId(nssa, true);
     }
 
+    public void resolve(boolean mustExist, SourceGeneratorLocalData localData, Reference<Boolean> isType, Reference<GraphTargetItem> objectType, Reference<GraphTargetItem> propertyType, Reference<Integer> propertyIndex, Reference<ValueKind> propertyValue, Reference<ABC> propertyValueABC, Reference<Trait> propertyTrait) throws CompilationException {
+        ResolveAccelerator accelerator = new ResolveAccelerator();
+
+        resolve(mustExist, localData, isType, objectType, propertyType, propertyIndex, propertyValue, propertyValueABC, propertyTrait, accelerator);
+    }
+
     /**
      * Resolves property.
      * @param mustExist Must exist
@@ -163,9 +171,10 @@ public class PropertyAVM2Item extends AssignableAVM2Item {
      * @param propertyIndex Property index
      * @param propertyValue Property value
      * @param propertyValueABC Property value ABC
+     * @param accelerator Resolve accelerator
      * @throws CompilationException On compilation error
      */
-    public void resolve(boolean mustExist, SourceGeneratorLocalData localData, Reference<Boolean> isType, Reference<GraphTargetItem> objectType, Reference<GraphTargetItem> propertyType, Reference<Integer> propertyIndex, Reference<ValueKind> propertyValue, Reference<ABC> propertyValueABC, Reference<Trait> propertyTrait) throws CompilationException {
+    public void resolve(boolean mustExist, SourceGeneratorLocalData localData, Reference<Boolean> isType, Reference<GraphTargetItem> objectType, Reference<GraphTargetItem> propertyType, Reference<Integer> propertyIndex, Reference<ValueKind> propertyValue, Reference<ABC> propertyValueABC, Reference<Trait> propertyTrait, ResolveAccelerator accelerator) throws CompilationException {
         List<Integer> openedNamespaceIds = new ArrayList<>();
         for (int i = 0; i < openedNamespaces.size(); i++) {
             if (!openedNamespaces.get(i).isResolved()) {
@@ -362,87 +371,17 @@ public class PropertyAVM2Item extends AssignableAVM2Item {
                 }
 
                 if (objType == null) {
-                    loopobjType:
-                    for (int nsindex : openedNamespaceIds) {
-                        Namespace ns = abcIndex.getSelectedAbc().constants.getNamespace(nsindex);
-                        int nsKind = ns.kind;
-                        DottedChain nsname = ns.getName(abcIndex.getSelectedAbc().constants);
-
-                        if (nsname.isTopLevel()) {
-                            continue;
+                    ResolveInOpenedNamespacesResult res = resolveInOpenedNamespaces(openedNamespaceIds, constants, abc, isType, namespaceSuffixInt, localData, accelerator);
+                    if (res != null) {
+                        objType = res.objType;
+                        propType = res.propType;
+                        propIndex = res.propIndex;
+                        if (res.hasValue) {
+                            propValue = res.propValue;
+                            propValueAbc = res.propValueAbc;
+                            propTrait = res.propTrait;
                         }
-
-                        int name_index = 0;
-                        int string_property_index = constants.getStringId(propertyName, false);
-                        if (string_property_index > -1) {
-                            for (int m = 1; m < constants.getMultinameCount(); m++) {
-                                Multiname mname = constants.getMultiname(m);
-                                if (mname.kind == Multiname.QNAME
-                                        && mname.name_index == string_property_index
-                                        && mname.namespace_index == nsindex) {
-                                    name_index = m;
-                                    break;
-                                }
-                            }
-                        }
-                        if (name_index > 0) {                        
-                            for (ScriptInfo si : abc.script_info) {
-                                if (si.deleted) {
-                                    continue;
-                                }
-                                for (Trait t : si.traits.traits) {
-                                    if (t.name_index == name_index) {
-                                        isType.setVal(t instanceof TraitClass);
-                                        objType = new TypeItem(DottedChain.OBJECT);
-                                        propType = AVM2SourceGenerator.getTraitReturnType(abcIndex, t);
-                                        propIndex = t.name_index;
-                                        if (t instanceof TraitSlotConst) {
-                                            TraitSlotConst tsc = (TraitSlotConst) t;
-                                            propValue = new ValueKind(tsc.value_index, tsc.value_kind);
-                                            propValueAbc = abc;
-                                            propTrait = t;
-                                        }
-                                        break loopobjType;
-                                    }
-                                }
-                            }
-                        }
-                        if (nsKind == Namespace.KIND_PACKAGE && propertyName != null) {
-                            Reference<Boolean> foundStatic = new Reference<>(null);
-                            AbcIndexing.TraitIndex p = abcIndex.findNsProperty(new AbcIndexing.PropertyNsDef(propertyName, nsname, abc, nsindex), true, true, foundStatic);
-
-                            Reference<String> outName = new Reference<>("");
-                            Reference<DottedChain> outNs = new Reference<>(DottedChain.EMPTY);
-                            Reference<DottedChain> outPropNs = new Reference<>(DottedChain.EMPTY);
-                            Reference<Integer> outPropNsKind = new Reference<>(1);
-                            Reference<Integer> outPropNsIndex = new Reference<>(0);
-                            Reference<GraphTargetItem> outPropType = new Reference<>(null);
-                            Reference<ValueKind> outPropValue = new Reference<>(null);
-                            Reference<ABC> outPropValueAbc = new Reference<>(null);
-                            Reference<Trait> outPropTrait = new Reference<>(null);
-                            if (p != null && (p.objType instanceof TypeItem)) {
-                                List<Integer> otherns = new ArrayList<>();
-                                otherns.addAll(openedNamespaceIds);
-                                /*for (NamespaceItem n : openedNamespaces) {
-                                    if (n.isResolved()) {
-                                        otherns.add(n.getCpoolIndex(abcIndex));
-                                    }
-                                }*/
-                                if (AVM2SourceGenerator.searchPrototypeChain(nsKeyword, namespaceSuffixInt, otherns, localData.privateNs, localData.protectedNs, localData.staticProtectedNs, localData.internalNs, false, abcIndex, nsname, (((TypeItem) p.objType).fullTypeName.getLast()), propertyName, outName, outNs, outPropNs, outPropNsKind, outPropNsIndex, outPropType, outPropValue, outPropValueAbc, isType, outPropTrait)) {
-                                    objType = new TypeItem(outNs.getVal().addWithSuffix(outName.getVal()));
-                                    propType = p.returnType;
-                                    propIndex = constants.getMultinameId(Multiname.createQName(false,
-                                            constants.getStringId(propertyName, true),
-                                            namespaceSuffixInt != null ? namespaceSuffixInt : constants.getNamespaceId(outPropNsKind.getVal(), outPropNs.getVal(), outPropNsIndex.getVal(), true)), true
-                                    );
-                                    propValue = p.value;
-                                    propValueAbc = outPropValueAbc.getVal();
-                                    propTrait = outPropTrait.getVal();
-                                    break loopobjType;
-                                }
-                            }
-                        }
-                    }                    
+                    }
                 }
             }
         }
@@ -470,6 +409,185 @@ public class PropertyAVM2Item extends AssignableAVM2Item {
         propertyType.setVal(propType);
         objectType.setVal(objType);
         propertyTrait.setVal(propTrait);
+    }
+
+    
+    private static class ResolveInOpenedNamespacesResult {
+        public GraphTargetItem objType;
+        public GraphTargetItem propType;
+        public int propIndex;
+        public boolean hasValue;
+        public ValueKind propValue;
+        public ABC propValueAbc;
+        public Trait propTrait;
+
+        public ResolveInOpenedNamespacesResult(GraphTargetItem objType, GraphTargetItem propType, int propIndex) {
+            this.objType = objType;
+            this.propType = propType;
+            this.propIndex = propIndex;
+        }
+
+        public void setValue(ValueKind propValue, ABC propValueAbc, Trait propTrait) {
+            this.hasValue = true;
+            this.propValue = propValue;
+            this.propValueAbc = propValueAbc;
+            this.propTrait = propTrait;
+        }
+    }
+
+    
+    private ResolveInOpenedNamespacesResult resolveInOpenedNamespaces(
+        List<Integer> openedNamespaceIds,
+        AVM2ConstantPool constants,
+        ABC abc,
+        Reference<Boolean> isType,
+        Integer namespaceSuffixInt,
+        SourceGeneratorLocalData localData,
+        ResolveAccelerator accelerator
+    ) {
+        
+        for (int nsindex : openedNamespaceIds) {
+            Namespace ns = abcIndex.getSelectedAbc().constants.getNamespace(nsindex);
+            int nsKind = ns.kind;
+            DottedChain nsname = ns.getName(abcIndex.getSelectedAbc().constants);
+
+            if (nsname.isTopLevel()) {
+                continue;
+            }
+
+            int name_index = resolveNameIndex(constants, nsindex, accelerator);
+            if (name_index > 0) {
+                for (ScriptInfo si : abc.script_info) {
+                    if (si.deleted) {
+                        continue;
+                    }
+                    for (Trait t : si.traits.traits) {
+                        if (t.name_index == name_index) {
+                            isType.setVal(t instanceof TraitClass);
+                            ResolveInOpenedNamespacesResult res = new ResolveInOpenedNamespacesResult(
+                                new TypeItem(DottedChain.OBJECT), 
+                                AVM2SourceGenerator.getTraitReturnType(abcIndex, t), 
+                                t.name_index);
+                            if (t instanceof TraitSlotConst) {
+                                TraitSlotConst tsc = (TraitSlotConst) t;
+                                res.setValue(new ValueKind(tsc.value_index, tsc.value_kind), abc, t);
+                            }
+                            return res;
+                        }
+                    }
+                }
+            }
+            if (nsKind == Namespace.KIND_PACKAGE && propertyName != null) {
+                Reference<Boolean> foundStatic = new Reference<>(null);
+                AbcIndexing.TraitIndex p = abcIndex.findNsProperty(new AbcIndexing.PropertyNsDef(propertyName, nsname, abc, nsindex), true, true, foundStatic);
+
+                Reference<String> outName = new Reference<>("");
+                Reference<DottedChain> outNs = new Reference<>(DottedChain.EMPTY);
+                Reference<DottedChain> outPropNs = new Reference<>(DottedChain.EMPTY);
+                Reference<Integer> outPropNsKind = new Reference<>(1);
+                Reference<Integer> outPropNsIndex = new Reference<>(0);
+                Reference<GraphTargetItem> outPropType = new Reference<>(null);
+                Reference<ValueKind> outPropValue = new Reference<>(null);
+                Reference<ABC> outPropValueAbc = new Reference<>(null);
+                Reference<Trait> outPropTrait = new Reference<>(null);
+                if (p != null && (p.objType instanceof TypeItem)) {
+                    List<Integer> otherns = new ArrayList<>();
+                    otherns.addAll(openedNamespaceIds);
+                    /*for (NamespaceItem n : openedNamespaces) {
+                        if (n.isResolved()) {
+                            otherns.add(n.getCpoolIndex(abcIndex));
+                        }
+                    }*/
+                    if (AVM2SourceGenerator.searchPrototypeChain(nsKeyword, namespaceSuffixInt, otherns, localData.privateNs, localData.protectedNs, localData.staticProtectedNs, localData.internalNs, false, abcIndex, nsname, (((TypeItem) p.objType).fullTypeName.getLast()), propertyName, outName, outNs, outPropNs, outPropNsKind, outPropNsIndex, outPropType, outPropValue, outPropValueAbc, isType, outPropTrait)) {
+                        GraphTargetItem objType = new TypeItem(outNs.getVal().addWithSuffix(outName.getVal()));
+                        GraphTargetItem propType = p.returnType;
+                        int propIndex = constants.getMultinameId(Multiname.createQName(false,
+                                constants.getStringId(propertyName, true),
+                                namespaceSuffixInt != null ? namespaceSuffixInt : constants.getNamespaceId(outPropNsKind.getVal(), outPropNs.getVal(), outPropNsIndex.getVal(), true)), true
+                        );
+                        ResolveInOpenedNamespacesResult res = new ResolveInOpenedNamespacesResult(
+                            objType, 
+                            propType, 
+                            propIndex);
+                        res.setValue(p.value, outPropValueAbc.getVal(), outPropTrait.getVal());
+                        return res;
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+
+    private static class LRULinkedHashMap<K, V> extends LinkedHashMap<K, V> {
+        private final int maxEntries;
+
+        public LRULinkedHashMap(int maxEntries) {
+            super(maxEntries + 1, 1.0f, true);
+            this.maxEntries = maxEntries;
+        }
+
+        @Override
+        protected boolean removeEldestEntry(Map.Entry<K, V> eldest) {
+            return size() > maxEntries;
+        }
+    }
+
+    private static class ResolveNameIndexKey {
+        int nsindex;
+        int string_property_index;
+
+        public ResolveNameIndexKey(int nsindex, int string_property_index) {
+            this.nsindex = nsindex;
+            this.string_property_index = string_property_index;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(nsindex, string_property_index);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null || getClass() != obj.getClass()) {
+                return false;
+            }
+            ResolveNameIndexKey other = (ResolveNameIndexKey) obj;
+            return nsindex == other.nsindex && string_property_index == other.string_property_index;
+        }
+    }
+    
+    public static class ResolveAccelerator {
+        public LinkedHashMap<ResolveNameIndexKey, Integer> multinameIndexCache = new LRULinkedHashMap<>(100);
+    }
+
+    private int resolveNameIndex(
+        AVM2ConstantPool constants,
+        int nsindex,
+        ResolveAccelerator accelerator
+    ) {
+        int string_property_index = constants.getStringId(propertyName, false);
+        if (string_property_index > -1) {
+            ResolveNameIndexKey key = new ResolveNameIndexKey(nsindex, string_property_index);
+            if (accelerator.multinameIndexCache.containsKey(key)) {
+                return accelerator.multinameIndexCache.get(key);
+            } else {
+                for (int m = 1; m < constants.getMultinameCount(); m++) {
+                    Multiname mname = constants.getMultiname(m);
+                    if (mname.kind == Multiname.QNAME
+                            && mname.name_index == string_property_index
+                            && mname.namespace_index == nsindex) {
+                        accelerator.multinameIndexCache.put(key, m);
+                        return m;
+                    }
+                }
+                accelerator.multinameIndexCache.put(key, 0);
+            }
+        }
+        return 0;
     }
 
     /**

--- a/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/abc/avm2/parser/script/UnresolvedAVM2Item.java
+++ b/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/abc/avm2/parser/script/UnresolvedAVM2Item.java
@@ -409,58 +409,126 @@ public class UnresolvedAVM2Item extends AssignableAVM2Item {
      * @return Resolved item
      * @throws CompilationException On compilation error
      */
-    public GraphTargetItem resolve(SourceGeneratorLocalData localData /*can be null!!!*/, String currentClassFullName, GraphTargetItem thisType, List<GraphTargetItem> paramTypes, List<String> paramNames, AbcIndexing abc, List<MethodBody> callStack, List<AssignableAVM2Item> variables) throws CompilationException {        
-        if (scopeStack.isEmpty()) { //Everything is multiname property in with command
+    public GraphTargetItem resolve(SourceGeneratorLocalData localData /*can be null!!!*/, String currentClassFullName, GraphTargetItem thisType, List<GraphTargetItem> paramTypes, List<String> paramNames, AbcIndexing abc, List<MethodBody> callStack, List<AssignableAVM2Item> variables) throws CompilationException {
+        boolean isResolved = false;
 
-            //search for variable
-            for (AssignableAVM2Item a : variables) {
-                if (a instanceof NameAVM2Item) {
-                    NameAVM2Item n = (NameAVM2Item) a;
-                    if (n.isDefinition() && name.get(0).equals(n.getVariableName())) {
-                        NameAVM2Item ret = new NameAVM2Item(n.type, n.line, name.isAttribute(0), name.get(0), name.getNamespaceSuffix(0), null, false, openedNamespaces, abcIndex, n.isConst());
-                        ret.setSlotScope(n.getSlotScope());
-                        ret.setSlotNumber(n.getSlotNumber());
-                        ret.setRegNumber(n.getRegNumber());
-                        resolved = ret;
-                        for (int i = 1; i < name.size(); i++) {
-                            resolved = new PropertyAVM2Item(resolved, name.isAttribute(i), name.get(i), name.getNamespaceSuffix(i), abc, openedNamespaces, new ArrayList<>(), false, null, line, this.thisType);
-                            if (i == name.size() - 1) {
-                                ((PropertyAVM2Item) resolved).assignedValue = assignedValue;
-                            }
-                        }
-                        if (name.size() == 1) {
-                            ret.setAssignedValue(assignedValue);
-                        }
-                        ret.setNs(n.getNs());
-                        return resolvedRoot = ret;
-                    }
-                }
-            }
+        if (scopeStack.isEmpty()) { //Everything is multiname property in with command
+            isResolved = resolve1(localData, currentClassFullName, thisType, paramTypes, paramNames, abc, callStack, variables);
+            if (isResolved) { return resolvedRoot; }
         }
 
         if ((paramNames.contains(name.get(0)) || name.get(0).equals("arguments"))) {
-            int ind = paramNames.indexOf(name.get(0));
-            GraphTargetItem t = TypeItem.UNBOUNDED;
-            if (ind == -1) {
-                //empty
-            } else if (ind < paramTypes.size()) {
-                t = paramTypes.get(ind);
-            } //else rest parameter
+            isResolved = resolve2(localData, currentClassFullName, thisType, paramTypes, paramNames, abc, callStack, variables);
+            if (isResolved) { return resolvedRoot; }
+        }
 
-            GraphTargetItem ret = new NameAVM2Item(t, line, name.isAttribute(0), name.get(0), name.getNamespaceSuffix(0), null, false, openedNamespaces, abcIndex, false);
+        boolean isProperty = resolve3(localData, currentClassFullName, thisType, paramTypes, paramNames, abc, callStack, variables);
+
+        //search same package classes
+        if (currentClassFullName != null && !isProperty) {
+            isResolved = resolve4(localData, currentClassFullName, thisType, paramTypes, paramNames, abc, callStack, variables);
+            if (isResolved) { return resolvedRoot; }
+        }
+
+        //Search toplevel classes
+        if (currentClassFullName != null && !isProperty) {
+            isResolved = resolve5(localData, currentClassFullName, thisType, paramTypes, paramNames, abc, callStack, variables);
+            if (isResolved) { return resolvedRoot; }
+        }
+
+        //Search for types in imported classes
+        if (!isProperty) {
+            isResolved = resolve6(localData, currentClassFullName, thisType, paramTypes, paramNames, abc, callStack, variables);
+            if (isResolved) { return resolvedRoot; }
+        }
+
+        //Search all fully qualified types
+        if (!isProperty) {
+            isResolved = resolve7(localData, currentClassFullName, thisType, paramTypes, paramNames, abc, callStack, variables);
+            if (isResolved) { return resolvedRoot; }
+
+            isResolved = resolve8(localData, currentClassFullName, thisType, paramTypes, paramNames, abc, callStack, variables);
+            if (isResolved) { return resolvedRoot; }
+        }
+
+        if (!isProperty && (name.get(0).equals("this") || name.get(0).equals("super"))) {
+            if (thisType == null) {
+                throw new CompilationException("Cannot use this in that context", line);
+            }
+
+            isResolved = resolve9(localData, currentClassFullName, thisType, paramTypes, paramNames, abc, callStack, variables);
+            if (isResolved) { return resolvedRoot; }
+        }
+
+        if (!isProperty && (name.size() == 1 && name.get(0).equals("Vector"))) {
+            TypeItem ret = new TypeItem(InitVectorAVM2Item.VECTOR_FQN);
             resolved = ret;
-            for (int i = 1; i < name.size(); i++) {
-                resolved = new PropertyAVM2Item(resolved, name.isAttribute(i), name.get(i), name.getNamespaceSuffix(i), abc, openedNamespaces, new ArrayList<>(), false, null, line, this.thisType);
-                if (i == name.size() - 1) {
-                    ((PropertyAVM2Item) resolved).assignedValue = assignedValue;
-                }
-            }
-            if (name.size() == 1) {
-                ((NameAVM2Item) ret).setAssignedValue(assignedValue);
-            }
             return resolvedRoot = ret;
         }
 
+        if (mustBeType) {
+            throw new CompilationException(name.toPrintableString(new LinkedHashSet<>(), abcIndex.getSelectedAbc().getSwf(), true) + " is not an existing type", line);
+        }
+
+        resolve10(localData, currentClassFullName, thisType, paramTypes, paramNames, abc, callStack, variables);
+        return resolvedRoot;
+    }
+
+    private boolean resolve1(SourceGeneratorLocalData localData /*can be null!!!*/, String currentClassFullName, GraphTargetItem thisType, List<GraphTargetItem> paramTypes, List<String> paramNames, AbcIndexing abc, List<MethodBody> callStack, List<AssignableAVM2Item> variables) throws CompilationException {
+        //search for variable
+        for (AssignableAVM2Item a : variables) {
+            if (a instanceof NameAVM2Item) {
+                NameAVM2Item n = (NameAVM2Item) a;
+                if (n.isDefinition() && name.get(0).equals(n.getVariableName())) {
+                    NameAVM2Item ret = new NameAVM2Item(n.type, n.line, name.isAttribute(0), name.get(0), name.getNamespaceSuffix(0), null, false, openedNamespaces, abcIndex, n.isConst());
+                    ret.setSlotScope(n.getSlotScope());
+                    ret.setSlotNumber(n.getSlotNumber());
+                    ret.setRegNumber(n.getRegNumber());
+                    resolved = ret;
+                    for (int i = 1; i < name.size(); i++) {
+                        resolved = new PropertyAVM2Item(resolved, name.isAttribute(i), name.get(i), name.getNamespaceSuffix(i), abc, openedNamespaces, new ArrayList<>(), false, null, line, this.thisType);
+                        if (i == name.size() - 1) {
+                            ((PropertyAVM2Item) resolved).assignedValue = assignedValue;
+                        }
+                    }
+                    if (name.size() == 1) {
+                        ret.setAssignedValue(assignedValue);
+                    }
+                    ret.setNs(n.getNs());
+                    resolvedRoot = ret;
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private boolean resolve2(SourceGeneratorLocalData localData /*can be null!!!*/, String currentClassFullName, GraphTargetItem thisType, List<GraphTargetItem> paramTypes, List<String> paramNames, AbcIndexing abc, List<MethodBody> callStack, List<AssignableAVM2Item> variables) throws CompilationException {
+        int ind = paramNames.indexOf(name.get(0));
+        GraphTargetItem t = TypeItem.UNBOUNDED;
+        if (ind == -1) {
+            //empty
+        } else if (ind < paramTypes.size()) {
+            t = paramTypes.get(ind);
+        } //else rest parameter
+
+        GraphTargetItem ret = new NameAVM2Item(t, line, name.isAttribute(0), name.get(0), name.getNamespaceSuffix(0), null, false, openedNamespaces, abcIndex, false);
+        resolved = ret;
+        for (int i = 1; i < name.size(); i++) {
+            resolved = new PropertyAVM2Item(resolved, name.isAttribute(i), name.get(i), name.getNamespaceSuffix(i), abc, openedNamespaces, new ArrayList<>(), false, null, line, this.thisType);
+            if (i == name.size() - 1) {
+                ((PropertyAVM2Item) resolved).assignedValue = assignedValue;
+            }
+        }
+        if (name.size() == 1) {
+            ((NameAVM2Item) ret).setAssignedValue(assignedValue);
+        }
+        resolvedRoot = ret;
+        return true;
+    }
+
+    private boolean resolve3(SourceGeneratorLocalData localData /*can be null!!!*/, String currentClassFullName, GraphTargetItem thisType, List<GraphTargetItem> paramTypes, List<String> paramNames, AbcIndexing abc, List<MethodBody> callStack, List<AssignableAVM2Item> variables) throws CompilationException {
         boolean isProperty = false;
         if (localData != null) { //resolve can be called without localData
             PropertyAVM2Item resolvedx = new PropertyAVM2Item(null, name.isAttribute(0), name.get(0), name.getNamespaceSuffix(0), abc, openedNamespaces, callStack, false, null, line, this.thisType);
@@ -481,43 +549,18 @@ public class UnresolvedAVM2Item extends AssignableAVM2Item {
             }
         }
 
-        //search same package classes
-        if (currentClassFullName != null && !isProperty) {
-            DottedChain classChain = DottedChain.parseWithSuffix(currentClassFullName);
-            DottedChain pkg = classChain.getWithoutLast();
+        return isProperty;
+    }
 
-            if (!pkg.isTopLevel()) { //toplevel in next step
-                TypeItem ti = new TypeItem(pkg.addWithSuffix(name.get(0)));
-                AbcIndexing.ClassIndex ci = abc.findClass(ti, null, null/*FIXME?*/);
+    private boolean resolve4(SourceGeneratorLocalData localData /*can be null!!!*/, String currentClassFullName, GraphTargetItem thisType, List<GraphTargetItem> paramTypes, List<String> paramNames, AbcIndexing abc, List<MethodBody> callStack, List<AssignableAVM2Item> variables) throws CompilationException {
+        DottedChain classChain = DottedChain.parseWithSuffix(currentClassFullName);
+        DottedChain pkg = classChain.getWithoutLast();
 
-                if (ci != null) {
-                    resolved = ti;
-                    for (int i = 1; i < name.size(); i++) {
-                        resolved = new PropertyAVM2Item(resolved, name.isAttribute(i), name.get(i), name.getNamespaceSuffix(i), abc, openedNamespaces, new ArrayList<>(), false, null, line, this.thisType);
-                        if (i == name.size() - 1) {
-                            ((PropertyAVM2Item) resolved).assignedValue = assignedValue;
-                        }
-                    }
-                    return resolvedRoot = ti;
-                }
-            }
-        }
-
-        //Search toplevel classes
-        if (currentClassFullName != null && !isProperty) {
-            DottedChain pkg = DottedChain.TOPLEVEL;
-
+        if (!pkg.isTopLevel()) { //toplevel in next step
             TypeItem ti = new TypeItem(pkg.addWithSuffix(name.get(0)));
             AbcIndexing.ClassIndex ci = abc.findClass(ti, null, null/*FIXME?*/);
 
             if (ci != null) {
-                for (DottedChain imp : importedClasses) {
-                    String impName = imp.getLast();
-
-                    if (impName.equals(name.get(0))) {
-                        throw new CompilationException("The type \"" + name.get(0) + "\" exists on toplevel package and also as an import from different package. Please make it fully qualified so it matches the desired import.", line);
-                    }
-                }
                 resolved = ti;
                 for (int i = 1; i < name.size(); i++) {
                     resolved = new PropertyAVM2Item(resolved, name.isAttribute(i), name.get(i), name.getNamespaceSuffix(i), abc, openedNamespaces, new ArrayList<>(), false, null, line, this.thisType);
@@ -525,143 +568,171 @@ public class UnresolvedAVM2Item extends AssignableAVM2Item {
                         ((PropertyAVM2Item) resolved).assignedValue = assignedValue;
                     }
                 }
-                return resolvedRoot = ti;
+                    resolvedRoot = ti;
+                return true;
             }
         }
+        return false;
+    }
 
-        //Search for types in imported classes
-        if (!isProperty) {
+
+    private boolean resolve5(SourceGeneratorLocalData localData /*can be null!!!*/, String currentClassFullName, GraphTargetItem thisType, List<GraphTargetItem> paramTypes, List<String> paramNames, AbcIndexing abc, List<MethodBody> callStack, List<AssignableAVM2Item> variables) throws CompilationException {
+        DottedChain pkg = DottedChain.TOPLEVEL;
+
+        TypeItem ti = new TypeItem(pkg.addWithSuffix(name.get(0)));
+        AbcIndexing.ClassIndex ci = abc.findClass(ti, null, null/*FIXME?*/);
+
+        if (ci != null) {
             for (DottedChain imp : importedClasses) {
                 String impName = imp.getLast();
 
                 if (impName.equals(name.get(0))) {
-                    TypeItem ret = new TypeItem(imp);
-                    
-                    resolved = ret;
-                    for (int i = 1; i < name.size(); i++) {
-                        resolved = new PropertyAVM2Item(resolved, name.isAttribute(i), name.get(i), name.getNamespaceSuffix(i), abc, openedNamespaces, new ArrayList<>(), false, null, line, this.thisType);
-                        if (i == name.size() - 1) {
-                            ((PropertyAVM2Item) resolved).assignedValue = assignedValue;
-                        }
-                    }
-
-                    if (name.size() == 1) {                        
-                        AbcIndexing.ClassIndex ci = abc.findClass(ret, abc.getSelectedAbc(), localData == null ? null : localData.scriptIndex);
-                        if (ci == null) {
-                            AbcIndexing.TraitIndex ti = abc.findScriptProperty(imp);
-                            if (ti != null) {
-                                resolved = new ScriptPropertyAVM2Item(ret);
-                                if (assignedValue != null) {
-                                    ((ScriptPropertyAVM2Item) resolved).assignedValue = assignedValue;
-                                }
-                                return resolvedRoot = resolved;
-                            }
-                        }                                                
-                    }
-
-                    return resolvedRoot = ret;
+                    throw new CompilationException("The type \"" + name.get(0) + "\" exists on toplevel package and also as an import from different package. Please make it fully qualified so it matches the desired import.", line);
                 }
             }
-        }
-
-        //Search all fully qualified types
-        if (!isProperty) {
-            for (int i = 0; i < name.size(); i++) {
-                DottedChain fname = name.subChain(i + 1);
-                AbcIndexing.ClassIndex ci = abc.findClass(new TypeItem(fname), localData != null ? abc.getSelectedAbc() : null, localData != null ? localData.scriptIndex : null);
-                if (ci != null) {
-                    if (!subtypes.isEmpty() && name.size() > i + 1) {
-                        continue;
-                    }
-                    TypeItem ret = new TypeItem(fname);
-                    resolved = ret;
-                    for (int j = i + 1; j < name.size(); j++) {
-                        resolved = new PropertyAVM2Item(resolved, name.isAttribute(j), name.get(j), name.getNamespaceSuffix(j), abc, openedNamespaces, new ArrayList<>(), false, null, line, this.thisType);
-                        if (j == name.size() - 1) {
-                            ((PropertyAVM2Item) resolved).assignedValue = assignedValue;
-                        }
-                    }
-                    if (name.size() == i + 1 && assignedValue != null) {
-                        throw new CompilationException("Cannot assign type", line);
-                    }
-
-                    return resolvedRoot = ret;
-                }
-            }
-
-            DottedChain classChain = DottedChain.parseWithSuffix(currentClassFullName);
-            DottedChain pkg = classChain.getWithoutLast();
-
-            //Search for types in opened namespaces
-            for (NamespaceItem n : openedNamespaces) {
-                n.resolveCustomNs(abcIndex, importedClasses, pkg, openedNamespaces, localData);
-                Namespace ons = abc.getSelectedAbc().constants.getNamespace(n.getCpoolIndex(abc));
-                TypeItem ti = new TypeItem(ons.getName(abc.getSelectedAbc().constants).addWithSuffix(name.get(0)));
-                AbcIndexing.ClassIndex ci = abc.findClass(ti, null, null/*FIXME?*/);
-                if (ci != null) {
-                    if (!subtypes.isEmpty() && name.size() > 1) {
-                        continue;
-                    }
-                    TypeItem ret = ti;
-                    resolved = ret;
-                    for (int i = 1; i < name.size(); i++) {
-                        resolved = new PropertyAVM2Item(resolved, name.isAttribute(i), name.get(i), name.getNamespaceSuffix(i), abc, openedNamespaces, new ArrayList<>(), false, null, line, this.thisType);
-                        if (i == name.size() - 1) {
-                            ((PropertyAVM2Item) resolved).assignedValue = assignedValue;
-                        }
-                    }
-                    if (name.size() == 1 && assignedValue != null) {
-                        throw new CompilationException("Cannot assign type", line);
-                    }
-
-                    return resolvedRoot = ret;
-                }
-            }
-        }
-
-        if (!isProperty && (name.get(0).equals("this") || name.get(0).equals("super"))) {
-            if (thisType == null) {
-                throw new CompilationException("Cannot use this in that context", line);
-            }
-
-            boolean isSuper = name.get(0).equals("super");
-            GraphTargetItem ntype = thisType;
-            if (isSuper) {
-                AbcIndexing.ClassIndex ci = abc.findClass(thisType, null, null/*FIXME?*/);
-                if (ci == null) {
-                    throw new CompilationException("This class not found", line);
-                }
-                ci = ci.parent;
-                if (ci == null) {
-                    ntype = new TypeItem("Object");
-                } else {
-                    ntype = new TypeItem(ci.abc.instance_info.get(ci.index).getName(ci.abc.constants).getNameWithNamespace(new LinkedHashSet<>(), ci.abc, ci.abc.constants, true));
-                }
-            }
-
-            NameAVM2Item ret = new NameAVM2Item(ntype, line, name.isAttribute(0), name.get(0), name.getNamespaceSuffix(0), null, false, openedNamespaces, abcIndex, false);
-            resolved = ret;
+            resolved = ti;
             for (int i = 1; i < name.size(); i++) {
                 resolved = new PropertyAVM2Item(resolved, name.isAttribute(i), name.get(i), name.getNamespaceSuffix(i), abc, openedNamespaces, new ArrayList<>(), false, null, line, this.thisType);
                 if (i == name.size() - 1) {
                     ((PropertyAVM2Item) resolved).assignedValue = assignedValue;
                 }
             }
-            if (name.size() == 1) {
-                ret.setAssignedValue(assignedValue);
+            resolvedRoot = ti;
+            return true;
+        }
+        return false;
+    }
+
+    private boolean resolve6(SourceGeneratorLocalData localData /*can be null!!!*/, String currentClassFullName, GraphTargetItem thisType, List<GraphTargetItem> paramTypes, List<String> paramNames, AbcIndexing abc, List<MethodBody> callStack, List<AssignableAVM2Item> variables) throws CompilationException {
+        for (DottedChain imp : importedClasses) {
+            String impName = imp.getLast();
+
+            if (impName.equals(name.get(0))) {
+                TypeItem ret = new TypeItem(imp);
+                
+                resolved = ret;
+                for (int i = 1; i < name.size(); i++) {
+                    resolved = new PropertyAVM2Item(resolved, name.isAttribute(i), name.get(i), name.getNamespaceSuffix(i), abc, openedNamespaces, new ArrayList<>(), false, null, line, this.thisType);
+                    if (i == name.size() - 1) {
+                        ((PropertyAVM2Item) resolved).assignedValue = assignedValue;
+                    }
+                }
+
+                if (name.size() == 1) {                        
+                    AbcIndexing.ClassIndex ci = abc.findClass(ret, abc.getSelectedAbc(), localData == null ? null : localData.scriptIndex);
+                    if (ci == null) {
+                        AbcIndexing.TraitIndex ti = abc.findScriptProperty(imp);
+                        if (ti != null) {
+                            resolved = new ScriptPropertyAVM2Item(ret);
+                            if (assignedValue != null) {
+                                ((ScriptPropertyAVM2Item) resolved).assignedValue = assignedValue;
+                            }
+                            resolvedRoot = resolved;
+                            return true;
+                        }
+                    }                                                
+                }
+
+                resolvedRoot = ret;
+                return true;
             }
-            return resolvedRoot = ret;
+        }
+        return false;
+    }
+
+    private boolean resolve7(SourceGeneratorLocalData localData /*can be null!!!*/, String currentClassFullName, GraphTargetItem thisType, List<GraphTargetItem> paramTypes, List<String> paramNames, AbcIndexing abc, List<MethodBody> callStack, List<AssignableAVM2Item> variables) throws CompilationException {
+        for (int i = 0; i < name.size(); i++) {
+            DottedChain fname = name.subChain(i + 1);
+            AbcIndexing.ClassIndex ci = abc.findClass(new TypeItem(fname), localData != null ? abc.getSelectedAbc() : null, localData != null ? localData.scriptIndex : null);
+            if (ci != null) {
+                if (!subtypes.isEmpty() && name.size() > i + 1) {
+                    continue;
+                }
+                TypeItem ret = new TypeItem(fname);
+                resolved = ret;
+                for (int j = i + 1; j < name.size(); j++) {
+                    resolved = new PropertyAVM2Item(resolved, name.isAttribute(j), name.get(j), name.getNamespaceSuffix(j), abc, openedNamespaces, new ArrayList<>(), false, null, line, this.thisType);
+                    if (j == name.size() - 1) {
+                        ((PropertyAVM2Item) resolved).assignedValue = assignedValue;
+                    }
+                }
+                if (name.size() == i + 1 && assignedValue != null) {
+                    throw new CompilationException("Cannot assign type", line);
+                }
+
+                resolvedRoot = ret;
+                return true;
+            }
         }
 
-        if (!isProperty && (name.size() == 1 && name.get(0).equals("Vector"))) {
-            TypeItem ret = new TypeItem(InitVectorAVM2Item.VECTOR_FQN);
-            resolved = ret;
-            return resolvedRoot = ret;
+        return false;
+    }
+    
+    private boolean resolve8(SourceGeneratorLocalData localData /*can be null!!!*/, String currentClassFullName, GraphTargetItem thisType, List<GraphTargetItem> paramTypes, List<String> paramNames, AbcIndexing abc, List<MethodBody> callStack, List<AssignableAVM2Item> variables) throws CompilationException {
+        DottedChain classChain = DottedChain.parseWithSuffix(currentClassFullName);
+        DottedChain pkg = classChain.getWithoutLast();
+
+        //Search for types in opened namespaces
+        for (NamespaceItem n : openedNamespaces) {
+            n.resolveCustomNs(abcIndex, importedClasses, pkg, openedNamespaces, localData);
+            Namespace ons = abc.getSelectedAbc().constants.getNamespace(n.getCpoolIndex(abc));
+            TypeItem ti = new TypeItem(ons.getName(abc.getSelectedAbc().constants).addWithSuffix(name.get(0)));
+            AbcIndexing.ClassIndex ci = abc.findClass(ti, null, null/*FIXME?*/);
+            if (ci != null) {
+                if (!subtypes.isEmpty() && name.size() > 1) {
+                    continue;
+                }
+                TypeItem ret = ti;
+                resolved = ret;
+                for (int i = 1; i < name.size(); i++) {
+                    resolved = new PropertyAVM2Item(resolved, name.isAttribute(i), name.get(i), name.getNamespaceSuffix(i), abc, openedNamespaces, new ArrayList<>(), false, null, line, this.thisType);
+                    if (i == name.size() - 1) {
+                        ((PropertyAVM2Item) resolved).assignedValue = assignedValue;
+                    }
+                }
+                if (name.size() == 1 && assignedValue != null) {
+                    throw new CompilationException("Cannot assign type", line);
+                }
+
+                resolvedRoot = ret;
+                return true;
+            }
+        }
+        return false;
+
+    }
+    private boolean resolve9(SourceGeneratorLocalData localData /*can be null!!!*/, String currentClassFullName, GraphTargetItem thisType, List<GraphTargetItem> paramTypes, List<String> paramNames, AbcIndexing abc, List<MethodBody> callStack, List<AssignableAVM2Item> variables) throws CompilationException {
+        boolean isSuper = name.get(0).equals("super");
+        GraphTargetItem ntype = thisType;
+        if (isSuper) {
+            AbcIndexing.ClassIndex ci = abc.findClass(thisType, null, null/*FIXME?*/);
+            if (ci == null) {
+                throw new CompilationException("This class not found", line);
+            }
+            ci = ci.parent;
+            if (ci == null) {
+                ntype = new TypeItem("Object");
+            } else {
+                ntype = new TypeItem(ci.abc.instance_info.get(ci.index).getName(ci.abc.constants).getNameWithNamespace(new LinkedHashSet<>(), ci.abc, ci.abc.constants, true));
+            }
         }
 
-        if (mustBeType) {
-            throw new CompilationException(name.toPrintableString(new LinkedHashSet<>(), abcIndex.getSelectedAbc().getSwf(), true) + " is not an existing type", line);
+        NameAVM2Item ret = new NameAVM2Item(ntype, line, name.isAttribute(0), name.get(0), name.getNamespaceSuffix(0), null, false, openedNamespaces, abcIndex, false);
+        resolved = ret;
+        for (int i = 1; i < name.size(); i++) {
+            resolved = new PropertyAVM2Item(resolved, name.isAttribute(i), name.get(i), name.getNamespaceSuffix(i), abc, openedNamespaces, new ArrayList<>(), false, null, line, this.thisType);
+            if (i == name.size() - 1) {
+                ((PropertyAVM2Item) resolved).assignedValue = assignedValue;
+            }
         }
+        if (name.size() == 1) {
+            ret.setAssignedValue(assignedValue);
+        }
+        resolvedRoot = ret;
+        return true;
+    }
+
+    private boolean resolve10(SourceGeneratorLocalData localData /*can be null!!!*/, String currentClassFullName, GraphTargetItem thisType, List<GraphTargetItem> paramTypes, List<String> paramNames, AbcIndexing abc, List<MethodBody> callStack, List<AssignableAVM2Item> variables) throws CompilationException {
         resolved = null;
         GraphTargetItem ret = null;
         for (int i = 0; i < name.size(); i++) {
@@ -674,8 +745,12 @@ public class UnresolvedAVM2Item extends AssignableAVM2Item {
                 ((PropertyAVM2Item) resolved).setAssignedValue(assignedValue);
             }
         }
-        return resolvedRoot = ret;
+        resolvedRoot = ret;
+        return true;
     }
+
+
+
 
     @Override
     public int hashCode() {

--- a/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/abc/avm2/parser/script/UnresolvedAVM2Item.java
+++ b/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/abc/avm2/parser/script/UnresolvedAVM2Item.java
@@ -439,12 +439,16 @@ public class UnresolvedAVM2Item extends AssignableAVM2Item {
 
         if (scopeStack.isEmpty()) { //Everything is multiname property in with command
             isResolved = resolve1(localData, currentClassFullName, thisType, paramTypes, paramNames, abc, callStack, variables, accelerator);
-            if (isResolved) { return resolvedRoot; }
+            if (isResolved) {
+                return resolvedRoot;
+            }
         }
 
         if ((paramNames.contains(name.get(0)) || name.get(0).equals("arguments"))) {
             isResolved = resolve2(localData, currentClassFullName, thisType, paramTypes, paramNames, abc, callStack, variables);
-            if (isResolved) { return resolvedRoot; }
+            if (isResolved) {
+                return resolvedRoot;
+            }
         }
 
         boolean isProperty = resolve3(localData, currentClassFullName, thisType, paramTypes, paramNames, abc, callStack, variables, accelerator);
@@ -452,28 +456,38 @@ public class UnresolvedAVM2Item extends AssignableAVM2Item {
         //search same package classes
         if (currentClassFullName != null && !isProperty) {
             isResolved = resolve4(localData, currentClassFullName, thisType, paramTypes, paramNames, abc, callStack, variables);
-            if (isResolved) { return resolvedRoot; }
+            if (isResolved) {
+                return resolvedRoot;
+            }
         }
 
         //Search toplevel classes
         if (currentClassFullName != null && !isProperty) {
             isResolved = resolve5(localData, currentClassFullName, thisType, paramTypes, paramNames, abc, callStack, variables);
-            if (isResolved) { return resolvedRoot; }
+            if (isResolved) {
+                return resolvedRoot;
+            }
         }
 
         //Search for types in imported classes
         if (!isProperty) {
             isResolved = resolve6(localData, currentClassFullName, thisType, paramTypes, paramNames, abc, callStack, variables);
-            if (isResolved) { return resolvedRoot; }
+            if (isResolved) {
+                return resolvedRoot;
+            }
         }
 
         //Search all fully qualified types
         if (!isProperty) {
             isResolved = resolve7(localData, currentClassFullName, thisType, paramTypes, paramNames, abc, callStack, variables);
-            if (isResolved) { return resolvedRoot; }
+            if (isResolved) {
+                return resolvedRoot;
+            }
 
             isResolved = resolve8(localData, currentClassFullName, thisType, paramTypes, paramNames, abc, callStack, variables);
-            if (isResolved) { return resolvedRoot; }
+            if (isResolved) {
+                return resolvedRoot;
+            }
         }
 
         if (!isProperty && (name.get(0).equals("this") || name.get(0).equals("super"))) {
@@ -482,7 +496,9 @@ public class UnresolvedAVM2Item extends AssignableAVM2Item {
             }
 
             isResolved = resolve9(localData, currentClassFullName, thisType, paramTypes, paramNames, abc, callStack, variables);
-            if (isResolved) { return resolvedRoot; }
+            if (isResolved) {
+                return resolvedRoot;
+            }
         }
 
         if (!isProperty && (name.size() == 1 && name.get(0).equals("Vector"))) {
@@ -502,7 +518,9 @@ public class UnresolvedAVM2Item extends AssignableAVM2Item {
     private boolean resolve1(SourceGeneratorLocalData localData /*can be null!!!*/, String currentClassFullName, GraphTargetItem thisType, List<GraphTargetItem> paramTypes, List<String> paramNames, AbcIndexing abc, List<MethodBody> callStack, List<AssignableAVM2Item> variables, ResolveAccelerator accelerator) throws CompilationException {
         //search for variable
         NameAVM2Item n = accelerator.definitionNameIndex.get(name.get(0));
-        if (n == null) { return false; }
+        if (n == null) {
+            return false;
+        }
 
         NameAVM2Item ret = new NameAVM2Item(n.type, n.line, name.isAttribute(0), name.get(0), name.getNamespaceSuffix(0), null, false, openedNamespaces, abcIndex, n.isConst());
         ret.setSlotScope(n.getSlotScope());
@@ -587,7 +605,7 @@ public class UnresolvedAVM2Item extends AssignableAVM2Item {
                         ((PropertyAVM2Item) resolved).assignedValue = assignedValue;
                     }
                 }
-                    resolvedRoot = ti;
+                resolvedRoot = ti;
                 return true;
             }
         }

--- a/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/abc/avm2/parser/script/UnresolvedAVM2Item.java
+++ b/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/abc/avm2/parser/script/UnresolvedAVM2Item.java
@@ -399,6 +399,7 @@ public class UnresolvedAVM2Item extends AssignableAVM2Item {
 
     public static class ResolveAccelerator {
         public HashMap<String, NameAVM2Item> definitionNameIndex = new HashMap<>();
+        public PropertyAVM2Item.ResolveAccelerator propertyResolveAccelerator = new PropertyAVM2Item.ResolveAccelerator();
 
         public ResolveAccelerator(List<AssignableAVM2Item> variables) {
             for (AssignableAVM2Item an : variables) {
@@ -446,7 +447,7 @@ public class UnresolvedAVM2Item extends AssignableAVM2Item {
             if (isResolved) { return resolvedRoot; }
         }
 
-        boolean isProperty = resolve3(localData, currentClassFullName, thisType, paramTypes, paramNames, abc, callStack, variables);
+        boolean isProperty = resolve3(localData, currentClassFullName, thisType, paramTypes, paramNames, abc, callStack, variables, accelerator);
 
         //search same package classes
         if (currentClassFullName != null && !isProperty) {
@@ -546,7 +547,7 @@ public class UnresolvedAVM2Item extends AssignableAVM2Item {
         return true;
     }
 
-    private boolean resolve3(SourceGeneratorLocalData localData /*can be null!!!*/, String currentClassFullName, GraphTargetItem thisType, List<GraphTargetItem> paramTypes, List<String> paramNames, AbcIndexing abc, List<MethodBody> callStack, List<AssignableAVM2Item> variables) throws CompilationException {
+    private boolean resolve3(SourceGeneratorLocalData localData /*can be null!!!*/, String currentClassFullName, GraphTargetItem thisType, List<GraphTargetItem> paramTypes, List<String> paramNames, AbcIndexing abc, List<MethodBody> callStack, List<AssignableAVM2Item> variables, ResolveAccelerator accelerator) throws CompilationException {
         boolean isProperty = false;
         if (localData != null) { //resolve can be called without localData
             PropertyAVM2Item resolvedx = new PropertyAVM2Item(null, name.isAttribute(0), name.get(0), name.getNamespaceSuffix(0), abc, openedNamespaces, callStack, false, null, line, this.thisType);
@@ -560,7 +561,7 @@ public class UnresolvedAVM2Item extends AssignableAVM2Item {
             Reference<Boolean> isType = new Reference<>(false);
             Reference<Trait> outPropTrait = new Reference<>(null);
 
-            resolvedx.resolve(true, localData, isType, objectType, propertyType, propertyIndex, propertyValue, propertyValueABC, outPropTrait);
+            resolvedx.resolve(true, localData, isType, objectType, propertyType, propertyIndex, propertyValue, propertyValueABC, outPropTrait, accelerator.propertyResolveAccelerator);
 
             if (objectType.getVal() != null && !isType.getVal()) {
                 isProperty = true;
@@ -717,8 +718,8 @@ public class UnresolvedAVM2Item extends AssignableAVM2Item {
             }
         }
         return false;
-
     }
+
     private boolean resolve9(SourceGeneratorLocalData localData /*can be null!!!*/, String currentClassFullName, GraphTargetItem thisType, List<GraphTargetItem> paramTypes, List<String> paramNames, AbcIndexing abc, List<MethodBody> callStack, List<AssignableAVM2Item> variables) throws CompilationException {
         boolean isSuper = name.get(0).equals("super");
         GraphTargetItem ntype = thisType;
@@ -766,9 +767,6 @@ public class UnresolvedAVM2Item extends AssignableAVM2Item {
         resolvedRoot = ret;
         return true;
     }
-
-
-
 
     @Override
     public int hashCode() {

--- a/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/abc/avm2/parser/script/UnresolvedAVM2Item.java
+++ b/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/abc/avm2/parser/script/UnresolvedAVM2Item.java
@@ -41,6 +41,7 @@ import com.jpexs.decompiler.graph.TypeItem;
 import com.jpexs.decompiler.graph.model.LocalData;
 import com.jpexs.helpers.Reference;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -396,6 +397,28 @@ public class UnresolvedAVM2Item extends AssignableAVM2Item {
         throw new CompilationException("Cannot assign", line);
     }
 
+    public static class ResolveAccelerator {
+        public HashMap<String, NameAVM2Item> definitionNameIndex = new HashMap<>();
+
+        public ResolveAccelerator(List<AssignableAVM2Item> variables) {
+            for (AssignableAVM2Item an : variables) {
+                if (an instanceof NameAVM2Item) {
+                    NameAVM2Item n = (NameAVM2Item) an;
+                    if (n.isDefinition() && !definitionNameIndex.containsKey(n.getVariableName())) {
+                        definitionNameIndex.put(n.getVariableName(), n);
+                    }
+                }
+            }
+        }
+    }
+
+    public GraphTargetItem resolve(SourceGeneratorLocalData localData /*can be null!!!*/, String currentClassFullName, GraphTargetItem thisType, List<GraphTargetItem> paramTypes, List<String> paramNames, AbcIndexing abc, List<MethodBody> callStack, List<AssignableAVM2Item> variables) throws CompilationException {        
+        ResolveAccelerator accelerator = new ResolveAccelerator(variables);
+
+        return resolve(localData, currentClassFullName, thisType, paramTypes, paramNames, abc, callStack, variables, accelerator);
+    }
+
+
     /**
      * Resolves.
      * @param localData Local data
@@ -406,14 +429,15 @@ public class UnresolvedAVM2Item extends AssignableAVM2Item {
      * @param abc ABC
      * @param callStack Call stack
      * @param variables Variables
+     * @param accelerator Resolve accelerator
      * @return Resolved item
      * @throws CompilationException On compilation error
      */
-    public GraphTargetItem resolve(SourceGeneratorLocalData localData /*can be null!!!*/, String currentClassFullName, GraphTargetItem thisType, List<GraphTargetItem> paramTypes, List<String> paramNames, AbcIndexing abc, List<MethodBody> callStack, List<AssignableAVM2Item> variables) throws CompilationException {
+    public GraphTargetItem resolve(SourceGeneratorLocalData localData /*can be null!!!*/, String currentClassFullName, GraphTargetItem thisType, List<GraphTargetItem> paramTypes, List<String> paramNames, AbcIndexing abc, List<MethodBody> callStack, List<AssignableAVM2Item> variables, ResolveAccelerator accelerator) throws CompilationException {
         boolean isResolved = false;
 
         if (scopeStack.isEmpty()) { //Everything is multiname property in with command
-            isResolved = resolve1(localData, currentClassFullName, thisType, paramTypes, paramNames, abc, callStack, variables);
+            isResolved = resolve1(localData, currentClassFullName, thisType, paramTypes, paramNames, abc, callStack, variables, accelerator);
             if (isResolved) { return resolvedRoot; }
         }
 
@@ -474,34 +498,28 @@ public class UnresolvedAVM2Item extends AssignableAVM2Item {
         return resolvedRoot;
     }
 
-    private boolean resolve1(SourceGeneratorLocalData localData /*can be null!!!*/, String currentClassFullName, GraphTargetItem thisType, List<GraphTargetItem> paramTypes, List<String> paramNames, AbcIndexing abc, List<MethodBody> callStack, List<AssignableAVM2Item> variables) throws CompilationException {
+    private boolean resolve1(SourceGeneratorLocalData localData /*can be null!!!*/, String currentClassFullName, GraphTargetItem thisType, List<GraphTargetItem> paramTypes, List<String> paramNames, AbcIndexing abc, List<MethodBody> callStack, List<AssignableAVM2Item> variables, ResolveAccelerator accelerator) throws CompilationException {
         //search for variable
-        for (AssignableAVM2Item a : variables) {
-            if (a instanceof NameAVM2Item) {
-                NameAVM2Item n = (NameAVM2Item) a;
-                if (n.isDefinition() && name.get(0).equals(n.getVariableName())) {
-                    NameAVM2Item ret = new NameAVM2Item(n.type, n.line, name.isAttribute(0), name.get(0), name.getNamespaceSuffix(0), null, false, openedNamespaces, abcIndex, n.isConst());
-                    ret.setSlotScope(n.getSlotScope());
-                    ret.setSlotNumber(n.getSlotNumber());
-                    ret.setRegNumber(n.getRegNumber());
-                    resolved = ret;
-                    for (int i = 1; i < name.size(); i++) {
-                        resolved = new PropertyAVM2Item(resolved, name.isAttribute(i), name.get(i), name.getNamespaceSuffix(i), abc, openedNamespaces, new ArrayList<>(), false, null, line, this.thisType);
-                        if (i == name.size() - 1) {
-                            ((PropertyAVM2Item) resolved).assignedValue = assignedValue;
-                        }
-                    }
-                    if (name.size() == 1) {
-                        ret.setAssignedValue(assignedValue);
-                    }
-                    ret.setNs(n.getNs());
-                    resolvedRoot = ret;
-                    return true;
-                }
+        NameAVM2Item n = accelerator.definitionNameIndex.get(name.get(0));
+        if (n == null) { return false; }
+
+        NameAVM2Item ret = new NameAVM2Item(n.type, n.line, name.isAttribute(0), name.get(0), name.getNamespaceSuffix(0), null, false, openedNamespaces, abcIndex, n.isConst());
+        ret.setSlotScope(n.getSlotScope());
+        ret.setSlotNumber(n.getSlotNumber());
+        ret.setRegNumber(n.getRegNumber());
+        resolved = ret;
+        for (int i = 1; i < name.size(); i++) {
+            resolved = new PropertyAVM2Item(resolved, name.isAttribute(i), name.get(i), name.getNamespaceSuffix(i), abc, openedNamespaces, new ArrayList<>(), false, null, line, this.thisType);
+            if (i == name.size() - 1) {
+                ((PropertyAVM2Item) resolved).assignedValue = assignedValue;
             }
         }
-
-        return false;
+        if (name.size() == 1) {
+            ret.setAssignedValue(assignedValue);
+        }
+        ret.setNs(n.getNs());
+        resolvedRoot = ret;
+        return true;
     }
 
     private boolean resolve2(SourceGeneratorLocalData localData /*can be null!!!*/, String currentClassFullName, GraphTargetItem thisType, List<GraphTargetItem> paramTypes, List<String> paramNames, AbcIndexing abc, List<MethodBody> callStack, List<AssignableAVM2Item> variables) throws CompilationException {

--- a/libsrc/ffdec_lib/src/com/jpexs/decompiler/graph/DottedChain.java
+++ b/libsrc/ffdec_lib/src/com/jpexs/decompiler/graph/DottedChain.java
@@ -27,6 +27,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 /**
  * Dotted chain class. Represents a chain of names separated by dots.
@@ -140,7 +141,7 @@ public class DottedChain implements Serializable, Comparable<DottedChain> {
             for (String part : parts) {
                 String nameNoSuffix = part;
                 String namespaceSuffix = "";
-                if (part.matches(".*#[0-9]+$")) {
+                if (NAME_PATTERN.matcher(part).matches()) {
                     nameNoSuffix = part.substring(0, part.lastIndexOf("#"));
                     namespaceSuffix = part.substring(part.lastIndexOf("#"));
                 }
@@ -364,6 +365,8 @@ public class DottedChain implements Serializable, Comparable<DottedChain> {
         return subChain(parts.size() - 1);
     }
 
+    private static final Pattern NAME_PATTERN = Pattern.compile(".*#[0-9]+$");
+
     /**
      * Adds a part to the chain with a suffix.
      *
@@ -373,7 +376,7 @@ public class DottedChain implements Serializable, Comparable<DottedChain> {
     public DottedChain addWithSuffix(String name) {
         String addedNameNoSuffix = name;
         String addedNamespaceSuffix = "";
-        if (name != null && name.matches(".*#[0-9]+$")) {
+        if (name != null && NAME_PATTERN.matcher(name).matches()) {
             addedNameNoSuffix = name.substring(0, name.lastIndexOf("#"));
             addedNamespaceSuffix = name.substring(name.lastIndexOf("#"));
         }

--- a/libsrc/ffdec_lib/src/com/jpexs/helpers/LRULinkedHashMap.java
+++ b/libsrc/ffdec_lib/src/com/jpexs/helpers/LRULinkedHashMap.java
@@ -1,0 +1,34 @@
+/*
+ *  Copyright (C) 2010-2026 JPEXS, All rights reserved.
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
+package com.jpexs.helpers;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class LRULinkedHashMap<K, V> extends LinkedHashMap<K, V> {
+    private final int maxEntries;
+
+    public LRULinkedHashMap(int maxEntries) {
+        super(maxEntries + 1, 1.0f, true);
+        this.maxEntries = maxEntries;
+    }
+
+    @Override
+    protected boolean removeEldestEntry(Map.Entry<K, V> eldest) {
+        return size() > maxEntries;
+    }
+}


### PR DESCRIPTION
A game I'm modding has an extremely large MainTimeline AS3 file, compiling the file takes minutes each time. Using VisualVM sampler, I found places that needed optimizations and implemented them.

Changes:
- optimized `AVM2SourceGenerator.searchPrototypeChain` by memoizing the entire call to `abc.findProperty`
- change `DottedChain.parseWithSuffix` and `addWithSuffix` to use a pre-compiled regex
- refactor `UnresolvedAVM2Item.resolve` into multiple private functions (helps in pin-pointing where performance problem is in VisualVM). they're named `resolve1` to `resolve10` for now
- add classes for storing data and precomputed hash maps for optimizing across `resolve` calls
- optimized `UnresolvedAVM2Item.resolve1` using a precomputed hash map
- optimized `PropertyAVM2Item.resolve` by refactoring parts of it into individual functions and memoizing name index lookup. (interestingly, just refactoring the `loopobjType` for loop into its own function with a custom return value class already cuts down the runtime by half without any other optimizations.)

Results:
I've tested on two different SWFs and scripts
First one ActionScript3Parser.compile total time from 65.8s to 6.6s
Second ActionScript3Parser.compile total time from 268.2 to 19.4s