### PR TITLE
version.major twice in same target

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -52,7 +52,6 @@
         <property name="version.major" value="0" />
         <property name="version.minor" value="0" />
         <property name="version.release" value="0" />
-        <property name="version.major" value="0" />
         <property name="version.build" value="0" />
         <!-- <property name="version.revision" value="" /> -->
         <property name="version.debug" value="true" />


### PR DESCRIPTION
Also, confirmed by chatgpt.
"You can safely remove the second version.major line without changing the build's behavior."