### PR TITLE
fix: keep original CharacterTag on duplicate characterId

### DIFF
--- a/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/SWF.java
+++ b/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/SWF.java
@@ -1729,10 +1729,10 @@ public final class SWF implements SWFContainerItem, Timelined, Openable {
                             CharacterTag ct = (CharacterTag) t;
                             CharacterTag oldCt = characters.get(characterId);
                             logger.log(Level.SEVERE, "SWF already contains characterId={0} of type {1}, tried to add type {2}", new Object[]{characterId, oldCt.getTagName(), ct.getTagName()});
+                        } else {
+                            characters.put(characterId, (CharacterTag) t);
+                            characterIdTags.put(characterId, new ArrayList<>());
                         }
-
-                        characters.put(characterId, (CharacterTag) t);
-                        characterIdTags.put(characterId, new ArrayList<>());
                     } else if (characterIdTags.containsKey(characterId)) {
                         characterIdTags.get(characterId).add((CharacterIdTag) t);
                     }

--- a/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/tags/base/TextTag.java
+++ b/libsrc/ffdec_lib/src/com/jpexs/decompiler/flash/tags/base/TextTag.java
@@ -1086,6 +1086,9 @@ public abstract class TextTag extends DrawableTag {
             }
             if (rec.styleFlagsHasFont) {
                 font = rec.getFont(swf);
+                if (font == null) {
+                    continue;
+                }
                 fontId = swf.getCharacterId(font);
                 if (exporter.getNormalizedFonts().containsKey(fontId)) {
                     font = exporter.getNormalizedFonts().get(fontId);


### PR DESCRIPTION
When two tags share the same characterId (e.g. DefineFont2 and DefineText2), keep the first-registered tag instead of overwriting. Also add null check in staticTextToSVG to skip text records with missing font instead of NPE.  
(AI used)